### PR TITLE
Check if script is already loaded before currying initialize into onLoad

### DIFF
--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -24,6 +24,11 @@ class ReactJWPlayer extends Component {
     this._initialize = this._initialize.bind(this);
   }
   componentDidMount() {
+    if (window.jwplayer) {
+      this._initialize();
+      return;
+    }
+
     const existingScript = document.getElementById(this.uniqueScriptId);
 
     if (!existingScript) {

--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -24,8 +24,8 @@ class ReactJWPlayer extends Component {
     this._initialize = this._initialize.bind(this);
   }
   componentDidMount() {
-    const scriptOnLoadAlreadyCalled = window.jwplayer;
-    if (scriptOnLoadAlreadyCalled) {
+    const jwPlayerScriptOnLoadAlreadyCalled = window.jwplayer;
+    if (jwPlayerScriptOnLoadAlreadyCalled) {
       this._initialize();
       return;
     }

--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -24,7 +24,8 @@ class ReactJWPlayer extends Component {
     this._initialize = this._initialize.bind(this);
   }
   componentDidMount() {
-    if (window.jwplayer) {
+    const scriptOnLoadAlreadyCalled = window.jwplayer;
+    if (scriptOnLoadAlreadyCalled) {
       this._initialize();
       return;
     }

--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -24,8 +24,8 @@ class ReactJWPlayer extends Component {
     this._initialize = this._initialize.bind(this);
   }
   componentDidMount() {
-    const jwPlayerScriptOnLoadAlreadyCalled = window.jwplayer;
-    if (jwPlayerScriptOnLoadAlreadyCalled) {
+    const isJWPlayerScriptLoaded = !!window.jwplayer;
+    if (isJWPlayerScriptLoaded) {
       this._initialize();
       return;
     }


### PR DESCRIPTION
Check if script is already loaded before currying initialize into onLoad. This fixes https://github.com/micnews/react-jw-player/issues/5.