### PR TITLE
Add ability to play individual files, not just playlists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ npm install react-jw-player
 
 ## Usage
 
-At the mininum, you can just use something like the following code.
+At the mininum, you can just use something like the two following code snippets:
+
+### Playing a JW Player JSON Playlist
 ``` javascript
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -35,7 +37,23 @@ ReactDOM.render(
   <ReactJWPlayer
     playerId='my-unique-id'
     playerScript='https://link-to-my-jw-player/script.js'
-    playlist='https://link-to-my-playlist-or-video'
+    playlist='https://link-to-my-playlist.json'
+  />,
+  document.getElementById('my-root-div');
+);
+```
+
+### Playing a Specific File
+``` javascript
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactJWPlayer from 'react-jw-player';
+
+ReactDOM.render(
+  <ReactJWPlayer
+    playerId='my-unique-id'
+    playerScript='https://link-to-my-jw-player/script.js'
+    file='https://link-to-my-video.mp4'
   />,
   document.getElementById('my-root-div');
 );
@@ -56,8 +74,8 @@ These are props that modify the basic behavior of the component.
   * Link to a valid JW Player script.
   * Type: `string`
   * Example: `https://content.jwplatform.com/libraries/abCD1234.js`
-* `playlist`
-  * Link to a valid JW Player video or playlist. Cool tip: JW Player automatically generates JSON feeds for individual videos if you use the video id in place of `abCD1234`. You can use this to get meta data on the videos without loading an actual playlist.
+* `playlist` OR `file`
+  * Link to a valid JW Player playlist or video file. Cool tip: JW Player automatically generates JSON feeds for individual videos if you use the video id in place of `abCD1234`. You can use this to get meta data on the videos without loading an actual playlist.
   * Type: `string`
   * Example: `https//content.jwplatform.com/feeds/abCD1234.json`
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf dist",
     "lint": "miclint | snazzy",
     "prepublish": "npm run lint && npm run test && npm run clean && npm run build",
-    "test": "npm run test:unit && npm run test:browser",
+    "test": "npm run lint && npm run test:unit && npm run test:browser",
     "test:unit": "babel-tape-runner ./test/*.test.js* | faucet",
     "test:browser": "babel-tape-runner ./test/*.browser-test.js* | faucet",
     "watch": "babel src --out-dir dist --watch"

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -2,6 +2,7 @@ const noOp = () => {};
 
 const defaultProps = {
   aspectRatio: 'inherit',
+  file: '',
   isMuted: false,
   onAdPlay: noOp,
   onAdResume: noOp,
@@ -24,6 +25,7 @@ const defaultProps = {
   onThirtySeconds: noOp,
   onFiftyPercent: noOp,
   onNinetyFivePercent: noOp,
+  playlist: '',
 };
 
 export default defaultProps;

--- a/src/helpers/get-player-opts.js
+++ b/src/helpers/get-player-opts.js
@@ -1,10 +1,15 @@
-function getPlayerOpts({ aspectRatio, playlist, isMuted, generatePrerollUrl }) {
+function getPlayerOpts({ aspectRatio, playlist, isMuted, generatePrerollUrl, file }) {
   const hasAdvertising = !!generatePrerollUrl;
 
   const playerOpts = {
-    playlist,
     mute: !!isMuted,
   };
+
+  if (playlist) {
+    playerOpts.playlist = playlist;
+  } else if (file) {
+    playerOpts.file = file;
+  }
 
   if (aspectRatio !== 'inherit') {
     playerOpts.aspectratio = aspectRatio;

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -3,6 +3,7 @@ import { PropTypes } from 'react';
 const propTypes = {
   aspectRatio: PropTypes.oneOf(['inherit', '1:1', '16:9']),
   className: PropTypes.string,
+  file: PropTypes.string,
   onAdPlay: PropTypes.func,
   onAdResume: PropTypes.func,
   onEnterFullScreen: PropTypes.func,
@@ -15,7 +16,7 @@ const propTypes = {
   generatePrerollUrl: PropTypes.func,
   onError: PropTypes.func,
   playerId: PropTypes.string.isRequired,
-  playlist: PropTypes.string.isRequired,
+  playlist: PropTypes.string,
   onReady: PropTypes.func,
   onAdPause: PropTypes.func,
   onPause: PropTypes.func,

--- a/test/get-player-opts.test.js
+++ b/test/get-player-opts.test.js
@@ -52,3 +52,30 @@ test('getPlayerOpts() with advertising', (t) => {
 
   t.end();
 });
+
+test('getPlayerOpts() with both a file and a playlist', (t) => {
+  const mockFile = 'mock file';
+  const mockPlaylist = 'mock playlist';
+
+  const actual = getPlayerOpts({
+    file: mockFile,
+    playlist: mockPlaylist,
+  });
+
+  t.equal(actual.playlist, mockPlaylist, 'it sets the playlist property');
+  t.notOk(actual.file, 'it does not set the file property');
+
+  t.end();
+});
+
+test('getPlayerOpts() with both only a file', (t) => {
+  const mockFile = 'mock file';
+
+  const actual = getPlayerOpts({
+    file: mockFile,
+  });
+
+  t.equal(actual.file, mockFile, 'it sets the file property');
+
+  t.end();
+});


### PR DESCRIPTION
# Add ability to play individual files, not just playlists.
This PR lets users add a `file` property instead of the original `playlist` option. If both are given, `playlist` will be given the priority.  Fixes https://github.com/micnews/react-jw-player/issues/4

## Type
Minor Change!

## Overview
* Allow `file` to be passed in as a prop.
* Adds linting to test script.
* Updates README to reflect new props.