### PR TITLE
Autoplay Abilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ These are props that modify the basic behavior of the component.
 * `className`
   * An optional class name to give the container div.
   * Type: `string`
+* `isAutoPlay`
+  * Determines whether the player starts automatically or not.
+  * Type: `boolean`
 * `isMuted`
   * Determines whether the player starts muted or not.
   * Type: `boolean`

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -3,6 +3,7 @@ const noOp = () => {};
 const defaultProps = {
   aspectRatio: 'inherit',
   file: '',
+  isAutoPlay: false,
   isMuted: false,
   onAdPlay: noOp,
   onAdResume: noOp,

--- a/src/helpers/get-player-opts.js
+++ b/src/helpers/get-player-opts.js
@@ -2,7 +2,6 @@ function getPlayerOpts({ aspectRatio, playlist, isAutoPlay, isMuted, generatePre
   const hasAdvertising = !!generatePrerollUrl;
 
   const playerOpts = {
-    autostart: isAutoPlay,
     mute: !!isMuted,
   };
 
@@ -12,7 +11,7 @@ function getPlayerOpts({ aspectRatio, playlist, isAutoPlay, isMuted, generatePre
     playerOpts.file = file;
   }
 
-  if (aspectRatio !== 'inherit') {
+  if (aspectRatio && aspectRatio !== 'inherit') {
     playerOpts.aspectratio = aspectRatio;
   }
 
@@ -22,6 +21,10 @@ function getPlayerOpts({ aspectRatio, playlist, isAutoPlay, isMuted, generatePre
       admessage: 'Ad — xxs left',
       autoplayadsmuted: true,
     };
+  }
+
+  if (typeof isAutoPlay !== 'undefined') {
+    playerOpts.autostart = !!isAutoPlay;
   }
 
   return playerOpts;

--- a/src/helpers/get-player-opts.js
+++ b/src/helpers/get-player-opts.js
@@ -1,7 +1,8 @@
-function getPlayerOpts({ aspectRatio, playlist, isMuted, generatePrerollUrl, file }) {
+function getPlayerOpts({ aspectRatio, playlist, isAutoPlay, isMuted, generatePrerollUrl, file }) {
   const hasAdvertising = !!generatePrerollUrl;
 
   const playerOpts = {
+    autostart: isAutoPlay,
     mute: !!isMuted,
   };
 

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -29,6 +29,7 @@ const propTypes = {
   onFiftyPercent: PropTypes.func,
   onNinetyFivePercent: PropTypes.func,
   isMuted: PropTypes.bool,
+  isAutoPlay: PropTypes.bool,
 };
 
 export default propTypes;

--- a/test/get-player-opts.test.js
+++ b/test/get-player-opts.test.js
@@ -10,8 +10,29 @@ test('getPlayerOpts() with defaults', (t) => {
 
   t.equal(actual.playlist, mockPlaylist, 'it sets the playlist property to the supplied playlist');
   t.equal(actual.mute, false, 'it sets the mute property to false');
-  t.notOk(actual.aspectratio, 'it does not set the aspect ratio property');
-  t.notOk(actual.advertising, 'it does not set advertising properties');
+  t.notOk(
+    Object.prototype.hasOwnProperty.call(actual, 'aspectratio'),
+    'it does not set aspectratio properties',
+  );
+  t.notOk(
+    Object.prototype.hasOwnProperty.call(actual, 'advertising'),
+    'it does not set advertising properties',
+  );
+
+  t.end();
+});
+
+test('getPlayerOpts() when isAutoPlay is not supplied', (t) => {
+  const mockPlaylist = 'mock playlist';
+
+  const actual = getPlayerOpts({
+    playlist: mockPlaylist,
+  });
+
+  t.notOk(
+    Object.prototype.hasOwnProperty.call(actual, 'autostart'),
+    'it does not set autostart properties',
+  );
 
   t.end();
 });
@@ -42,7 +63,10 @@ test('getPlayerOpts() when muted', (t) => {
   t.equal(actual.aspectratio, '1:1', 'it sets the aspect ratio properly');
   t.equal(actual.playlist, mockPlaylist, 'it sets the playlist property to the supplied playlist');
   t.equal(actual.mute, true, 'it sets the mute property to true');
-  t.notOk(actual.advertising, 'it does not set advertising properties');
+  t.notOk(
+    Object.prototype.hasOwnProperty.call(actual, 'advertising'),
+    'it does not set advertising properties',
+  );
 
   t.end();
 });
@@ -77,7 +101,7 @@ test('getPlayerOpts() with both a file and a playlist', (t) => {
   });
 
   t.equal(actual.playlist, mockPlaylist, 'it sets the playlist property');
-  t.notOk(actual.file, 'it does not set the file property');
+  t.notOk(Object.prototype.hasOwnProperty.call(actual, 'file'), 'it does not set file properties');
 
   t.end();
 });

--- a/test/get-player-opts.test.js
+++ b/test/get-player-opts.test.js
@@ -16,6 +16,20 @@ test('getPlayerOpts() with defaults', (t) => {
   t.end();
 });
 
+test('getPlayerOpts() when autoplay is on', (t) => {
+  const mockPlaylist = 'mock playlist';
+
+  const actual = getPlayerOpts({
+    isAutoPlay: true,
+    playlist: mockPlaylist,
+  });
+
+  t.equal(actual.playlist, mockPlaylist, 'it sets the playlist property to the supplied playlist');
+  t.equal(actual.autostart, true, 'it sets the autostart property to true');
+
+  t.end();
+});
+
 test('getPlayerOpts() when muted', (t) => {
   const mockPlaylist = 'mock playlist';
 


### PR DESCRIPTION
This allows the user to pass `isAutoPlay` and have the video load with autoplay capabilities. If not present, it will not override the defaults set in the loaded player script.

Also fixes an issue where `aspectratio` property was being set to `undefined` rather than not being set on the opts object at all.