### PR TITLE
move miclint from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,14 +40,13 @@
     "faucet": "0.0.1",
     "jsdom": "^9.9.1",
     "jsdom-global": "^2.1.1",
-    "miclint": "^3.0.0",
+    "miclint": "^4.1.0",
     "react-addons-test-utils": "^15.4.1",
     "react-dom": "^15.4.2",
     "snazzy": "^5.0.0",
     "tape": "^4.6.3"
   },
   "dependencies": {
-    "miclint": "^4.1.0",
     "react": "^15.4.1"
   }
 }


### PR DESCRIPTION
Remove redundant dependency. This also prevents users from installing unnecessary extraneous dependencies that might result in a broken environment. For example, a user might have configurations for eslint 2.2.0, this ends up replacing it with a more later version of eslint where their configurations are not compatible.