### PR TITLE
Fix ssr & updating props

### DIFF
--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -43,6 +43,11 @@ class ReactJWPlayer extends Component {
       existingScript.onload = getCurriedOnLoad(existingScript, this._initialize);
     }
   }
+  componentDidUpdate(prevProps) {
+    if (prevProps.playlist !== this.props.playlist || prevProps.file !== this.props.file) {
+      this._initialize();
+    }
+  }
   _initialize() {
     const component = this;
     const player = window.jwplayer(this.props.playerId);
@@ -52,7 +57,12 @@ class ReactJWPlayer extends Component {
   }
   render() {
     return (
-      <div className={this.props.className} id={this.props.playerId} />
+      <div
+        className={this.props.className}
+        dangerouslySetInnerHTML={{
+          __html: `<div id="${this.props.playerId}"></div>`,
+        }}
+      />
     );
   }
 }


### PR DESCRIPTION
This fixes a couple of issues when the player is updated

The first issue is when we render the player on the server, it gets a `data-reactid`, but when jwplayer initializes on this div, it strips out that attribute and React can't find it anymore. So we get an error. The `dangerouslySetInnerHTML` fixes this by moving the div outside of React's control.

The second issue is that the player doesn't reinitialize if the component is updated with new props. An example use case is a player that continuously plays (i.e. swaps in a new video file/playlist after the first one has finished playing). We need to explicitly call `_initialize()` if those props change.