### PR TITLE
Add the ability to pass in custom props.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ These are props that modify the basic behavior of the component.
 * `className`
   * An optional class name to give the container div.
   * Type: `string`
+* `customProps`
+  * An optional object containing properties to be applied directly to the JW Player instance. Add anything in the API, like skins, into this object. `customProps={{ skin: { name: 'six' } }}`.
+  * Type: `object`
 * `isAutoPlay`
   * Determines whether the player starts automatically or not.
   * Type: `boolean`

--- a/src/helpers/get-player-opts.js
+++ b/src/helpers/get-player-opts.js
@@ -1,6 +1,7 @@
 function getPlayerOpts(opts) {
   const {
     aspectRatio,
+    customProps = {},
     file,
     generatePrerollUrl,
     image,
@@ -41,7 +42,7 @@ function getPlayerOpts(opts) {
     playerOpts.image = image;
   }
 
-  return playerOpts;
+  return Object.assign(playerOpts, customProps);
 }
 
 export default getPlayerOpts;

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -3,6 +3,7 @@ import { PropTypes } from 'react';
 const propTypes = {
   aspectRatio: PropTypes.oneOf(['inherit', '1:1', '16:9']),
   className: PropTypes.string,
+  customProps: PropTypes.object,
   file: PropTypes.string,
   image: PropTypes.string,
   onAdPlay: PropTypes.func,

--- a/test/get-player-opts.test.js
+++ b/test/get-player-opts.test.js
@@ -129,3 +129,17 @@ test('getPlayerOpts() with image', (t) => {
 
   t.end();
 });
+
+test('getPlayerOpts() with customProps', (t) => {
+  const customProps = {
+    skin: {
+      name: 'five',
+    },
+  };
+
+  const actual = getPlayerOpts({ customProps });
+
+  t.deepEqual(actual.skin, customProps.skin, 'it sets customProps properly');
+
+  t.end();
+});


### PR DESCRIPTION
So we don't have to keep adding explicit support to features of the JW Player API, I'm proposing adding in a `customProps` object. Anything inside will be directly applied to the props on the JW Player instance rendered. Example:

```
customProps={{ skin: { name: 'six' } }}
```
Would result in passing `skin: { name: 'six'}` to JW Player's set-up command. This should make things more lightweight in the future, and give us the option of eventually completely deprecating most of the API matching we did in the initial version of this library.