### PR TITLE
Fix React.PropTypes, ReactTestUtils and Shallow renderer deprecation notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,13 +233,15 @@ These are props that modify the basic behavior of the component.
 ## Example Container Component
 ``` javascript
 import React from 'react';
+import PropTypes from 'prop-types';
+
 import ReactJWPlayer from 'react-jw-player';
 
 const displayName = 'ReactJWPlayerContainer';
 
 const propTypes = {
-  playlist: React.PropTypes.string.isRequired,
-  playerScript: React.PropTypes.string.isRequired
+  playlist: PropTypes.string.isRequired,
+  playerScript: PropTypes.string.isRequired
 };
 
 class ReactJWPlayerContainer extends React.Component {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "tape": "^4.6.3"
   },
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react": "^15.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "jsdom-global": "^2.1.1",
     "miclint": "^4.1.0",
     "react-addons-test-utils": "^15.4.1",
+    "react-test-renderer": "^15.4.2",
     "react-dom": "^15.4.2",
     "snazzy": "^5.0.0",
     "tape": "^4.6.3"

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 
 const propTypes = {
   aspectRatio: PropTypes.oneOf(['inherit', '1:1', '16:9']),


### PR DESCRIPTION
Added prop-types and react-test-renderer.
Updated README.md with new prop-types library.

Please test. :)