### PR TITLE
[WIP] Implement additional ad and time event hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 dist
 node_modules
-
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ These are props that modify the basic behavior of the component.
   * Arguments:
     * `event`
       * This is the event object passed back from JW Player itself.
+* `onAdComplete(event)`
+  * A function that is run when the user completes the preroll advertisement.
+  * Type: `function`
+  * Arguments:
+    * `event`
+      * This is the event object passed back from JW Player itself.
 
 ## Optional Player Event Hook Props
 * `onAutoStart(event)`
@@ -196,6 +202,14 @@ These are props that modify the basic behavior of the component.
       * This is the event object passed back from JW Player itself.
 
 ## Optional Time Event Hook Props
+* `onEverySecond(event)`
+  * A function that is run when one second elapses in playhead, including ads.
+  * Type: `function`
+  * Arguments:
+    * `event`
+      * This is the event object passed back from JW Player itself.
+  * Return Value:
+    * `position`: integer
 * `onThreeSeconds(event)`
   * A function that is run when the playhead reaches passed the 3 second mark.
   * Type: `function`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jw-player",
-  "version": "1.8.0-alpha.3",
+  "version": "1.8.0-alpha.4",
   "description": "A React component for launching JW Player instances on the client.",
   "main": "dist/react-jw-player.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jw-player",
-  "version": "1.8.0-alpha.2",
+  "version": "1.8.0-alpha.3",
   "description": "A React component for launching JW Player instances on the client.",
   "main": "dist/react-jw-player.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jw-player",
-  "version": "1.9.0",
+  "version": "1.8.0-alpha.1",
   "description": "A React component for launching JW Player instances on the client.",
   "main": "dist/react-jw-player.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jw-player",
-  "version": "1.8.0-alpha.4",
+  "version": "1.8.0-alpha.5",
   "description": "A React component for launching JW Player instances on the client.",
   "main": "dist/react-jw-player.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jw-player",
-  "version": "1.8.0-alpha.1",
+  "version": "1.8.0-alpha.2",
   "description": "A React component for launching JW Player instances on the client.",
   "main": "dist/react-jw-player.js",
   "scripts": {

--- a/src/create-event-handlers/index.js
+++ b/src/create-event-handlers/index.js
@@ -1,4 +1,5 @@
 import onAdPlay from './on-ad-play';
+import onAdTime from './on-ad-time';
 import onBeforePlay from './on-before-play';
 import onFullScreen from './on-full-screen';
 import onMute from './on-mute';
@@ -9,6 +10,7 @@ import onVideoLoad from './on-video-load';
 function createEventHandlers(component) {
   return {
     onAdPlay: onAdPlay.bind(component),
+    onAdTime: onAdTime.bind(component),
     onBeforePlay: onBeforePlay.bind(component),
     onFullScreen: onFullScreen.bind(component),
     onMute: onMute.bind(component),

--- a/src/create-event-handlers/on-ad-time.js
+++ b/src/create-event-handlers/on-ad-time.js
@@ -1,0 +1,28 @@
+function onAdTime(event) {
+  const { previousPositionInteger = 0 } = this.state;
+  const { position } = event;
+  const currentPositionInteger = Math.floor(position);
+
+  if (previousPositionInteger === currentPositionInteger) {
+    return;
+  }
+
+  let shouldUpdateState = false;
+
+  if (currentPositionInteger === 0) {
+    shouldUpdateState = true;
+  }
+
+  if (currentPositionInteger > previousPositionInteger) {
+    this.props.onEverySecond(currentPositionInteger);
+    shouldUpdateState = true;
+  }
+
+  if (shouldUpdateState) {
+    this.setState({
+      previousPositionInteger: currentPositionInteger,
+    });
+  }
+}
+
+export default onAdTime;

--- a/src/create-event-handlers/on-ad-time.js
+++ b/src/create-event-handlers/on-ad-time.js
@@ -1,5 +1,5 @@
 function onAdTime(event) {
-  const { previousPositionInteger = 0 } = this.state;
+  const { previousPositionInteger } = this.state;
   const { position } = event;
   const currentPositionInteger = Math.floor(position);
 
@@ -7,22 +7,11 @@ function onAdTime(event) {
     return;
   }
 
-  let shouldUpdateState = false;
+  this.props.onEverySecond(currentPositionInteger);
 
-  if (currentPositionInteger === 0) {
-    shouldUpdateState = true;
-  }
-
-  if (currentPositionInteger > previousPositionInteger) {
-    this.props.onEverySecond(currentPositionInteger);
-    shouldUpdateState = true;
-  }
-
-  if (shouldUpdateState) {
-    this.setState({
-      previousPositionInteger: currentPositionInteger,
-    });
-  }
+  this.setState({
+    previousPositionInteger: currentPositionInteger,
+  });
 }
 
 export default onAdTime;

--- a/src/create-event-handlers/on-time.js
+++ b/src/create-event-handlers/on-time.js
@@ -10,24 +10,24 @@ function onTime(event) {
     }
 
     this.setState({ previousPos: position });
-  }
+  } else {
+    if (!hasFired.threeSeconds && position >= 3) {
+      this.props.onThreeSeconds();
+      hasFired.threeSeconds = true;
+      hasChanged = true;
+    }
 
-  if (!hasFired.threeSeconds && position >= 3) {
-    this.props.onThreeSeconds();
-    hasFired.threeSeconds = true;
-    hasChanged = true;
-  }
+    if (!hasFired.tenSeconds && position >= 10) {
+      this.props.onTenSeconds();
+      hasFired.tenSeconds = true;
+      hasChanged = true;
+    }
 
-  if (!hasFired.tenSeconds && position >= 10) {
-    this.props.onTenSeconds();
-    hasFired.tenSeconds = true;
-    hasChanged = true;
-  }
-
-  if (!hasFired.thirtySeconds && position >= 30) {
-    this.props.onThirtySeconds();
-    hasFired.thirtySeconds = true;
-    hasChanged = true;
+    if (!hasFired.thirtySeconds && position >= 30) {
+      this.props.onThirtySeconds();
+      hasFired.thirtySeconds = true;
+      hasChanged = true;
+    }
   }
 
   if (!hasFired.twentyFivePercent && ((position / duration) * 100) >= 25) {

--- a/src/create-event-handlers/on-time.js
+++ b/src/create-event-handlers/on-time.js
@@ -3,6 +3,10 @@ function onTime(event) {
   const { duration, position } = event;
   const currentPositionInteger = Math.floor(position);
 
+  if (previousPositionInteger === currentPositionInteger) {
+    return;
+  }
+
   let shouldUpdateState = false;
 
   if (currentPositionInteger === 0) {

--- a/src/create-event-handlers/on-time.js
+++ b/src/create-event-handlers/on-time.js
@@ -1,9 +1,9 @@
 function onTime(event) {
   const { hasFired, previousPosition } = this.state;
-  const { duration } = event;
+  const { duration, position } = event;
 
   const durationInteger = Math.floor(duration);
-  const currentPositionInteger = Math.floor(event.position);
+  const currentPositionInteger = Math.floor(position);
   const previousPositionInteger = previousPosition || 0;
 
   let shouldUpdateState = false;
@@ -35,7 +35,7 @@ function onTime(event) {
     shouldUpdateState = true;
   }
 
-  if (!hasFired.fiftyPercent && ((currentPositionInteger / durationInteger) * 100) >= 50) {
+  if (!hasFired.fiftyPercent && ((position / duration) * 100) >= 50) {
     this.props.onFiftyPercent();
     hasFired.fiftyPercent = true;
     shouldUpdateState = true;

--- a/src/create-event-handlers/on-time.js
+++ b/src/create-event-handlers/on-time.js
@@ -1,10 +1,7 @@
 function onTime(event) {
-  const { hasFired, previousPosition } = this.state;
+  const { hasFired, previousPositionInteger = 0 } = this.state;
   const { duration, position } = event;
-
-  const durationInteger = Math.floor(duration);
   const currentPositionInteger = Math.floor(position);
-  const previousPositionInteger = previousPosition || 0;
 
   let shouldUpdateState = false;
 
@@ -53,16 +50,10 @@ function onTime(event) {
     shouldUpdateState = true;
   }
 
-  if (!hasFired.OneHundredPercent && currentPositionInteger === durationInteger) {
-    this.props.onOneHundredPercent();
-    hasFired.OneHundredPercent = true;
-    shouldUpdateState = true;
-  }
-
   if (shouldUpdateState) {
     this.setState({
       hasFired,
-      previousPosition: currentPositionInteger,
+      previousPositionInteger: currentPositionInteger,
     });
   }
 }

--- a/src/create-event-handlers/on-time.js
+++ b/src/create-event-handlers/on-time.js
@@ -3,67 +3,51 @@ function onTime(event) {
   const { duration, position } = event;
   const currentPositionInteger = Math.floor(position);
 
-  let shouldUpdateState = false;
-
   if (previousPositionInteger === currentPositionInteger) {
     return;
-  } else if (!hasFired.zeroSecond && currentPositionInteger === 0) {
-    this.props.onEverySecond(0);
-    hasFired.zeroSecond = true;
-    shouldUpdateState = true;
-  } else {
-    this.props.onEverySecond(currentPositionInteger);
-    shouldUpdateState = true;
   }
+
+  this.props.onEverySecond(currentPositionInteger);
 
   if (!hasFired.threeSeconds && currentPositionInteger >= 3) {
     this.props.onThreeSeconds();
     hasFired.threeSeconds = true;
-    shouldUpdateState = true;
   }
 
   if (!hasFired.tenSeconds && currentPositionInteger >= 10) {
     this.props.onTenSeconds();
     hasFired.tenSeconds = true;
-    shouldUpdateState = true;
   }
 
   if (!hasFired.thirtySeconds && currentPositionInteger >= 30) {
     this.props.onThirtySeconds();
     hasFired.thirtySeconds = true;
-    shouldUpdateState = true;
   }
 
   if (!hasFired.twentyFivePercent && ((position / duration) * 100) >= 25) {
     this.props.onTwentyFivePercent();
     hasFired.twentyFivePercent = true;
-    shouldUpdateState = true;
   }
 
   if (!hasFired.fiftyPercent && ((position / duration) * 100) >= 50) {
     this.props.onFiftyPercent();
     hasFired.fiftyPercent = true;
-    shouldUpdateState = true;
   }
 
   if (!hasFired.seventyFivePercent && ((position / duration) * 100) >= 75) {
     this.props.onSeventyFivePercent();
     hasFired.seventyFivePercent = true;
-    shouldUpdateState = true;
   }
 
   if (!hasFired.ninetyFivePercent && ((position / duration) * 100) >= 95) {
     this.props.onNinetyFivePercent();
     hasFired.ninetyFivePercent = true;
-    shouldUpdateState = true;
   }
 
-  if (shouldUpdateState) {
-    this.setState({
-      hasFired,
-      previousPositionInteger: currentPositionInteger,
-    });
-  }
+  this.setState({
+    hasFired,
+    previousPositionInteger: currentPositionInteger,
+  });
 }
 
 export default onTime;

--- a/src/create-event-handlers/on-time.js
+++ b/src/create-event-handlers/on-time.js
@@ -1,5 +1,5 @@
 function onTime(event) {
-  const { hasFired, previousPositionInteger = 0 } = this.state;
+  const { hasFired, previousPositionInteger } = this.state;
   const { duration, position } = event;
   const currentPositionInteger = Math.floor(position);
 
@@ -7,7 +7,9 @@ function onTime(event) {
 
   if (previousPositionInteger === currentPositionInteger) {
     return;
-  } else if (currentPositionInteger === 0) {
+  } else if (!hasFired.zeroSecond && currentPositionInteger === 0) {
+    this.props.onEverySecond(0);
+    hasFired.zeroSecond = true;
     shouldUpdateState = true;
   } else {
     this.props.onEverySecond(currentPositionInteger);

--- a/src/create-event-handlers/on-time.js
+++ b/src/create-event-handlers/on-time.js
@@ -3,17 +3,13 @@ function onTime(event) {
   const { duration, position } = event;
   const currentPositionInteger = Math.floor(position);
 
-  if (previousPositionInteger === currentPositionInteger) {
-    return;
-  }
-
   let shouldUpdateState = false;
 
-  if (currentPositionInteger === 0) {
+  if (previousPositionInteger === currentPositionInteger) {
+    return;
+  } else if (currentPositionInteger === 0) {
     shouldUpdateState = true;
-  }
-
-  if (currentPositionInteger > previousPositionInteger) {
+  } else {
     this.props.onEverySecond(currentPositionInteger);
     shouldUpdateState = true;
   }
@@ -36,19 +32,25 @@ function onTime(event) {
     shouldUpdateState = true;
   }
 
+  if (!hasFired.twentyFivePercent && ((position / duration) * 100) >= 25) {
+    this.props.onTwentyFivePercent();
+    hasFired.twentyFivePercent = true;
+    shouldUpdateState = true;
+  }
+
   if (!hasFired.fiftyPercent && ((position / duration) * 100) >= 50) {
     this.props.onFiftyPercent();
     hasFired.fiftyPercent = true;
     shouldUpdateState = true;
   }
 
-  if (!hasFired.seventyFivePercent && (currentPositionInteger / durationInteger) * 100) >= 75) {
+  if (!hasFired.seventyFivePercent && ((position / duration) * 100) >= 75) {
     this.props.onSeventyFivePercent();
     hasFired.seventyFivePercent = true;
-    hasChanged = true;
+    shouldUpdateState = true;
   }
 
-  if (!hasFired.ninetyFivePercent && ((currentPositionInteger / durationInteger) * 100) >= 95) {
+  if (!hasFired.ninetyFivePercent && ((position / duration) * 100) >= 95) {
     this.props.onNinetyFivePercent();
     hasFired.ninetyFivePercent = true;
     shouldUpdateState = true;

--- a/src/create-event-handlers/on-time.js
+++ b/src/create-event-handlers/on-time.js
@@ -1,62 +1,68 @@
 function onTime(event) {
-  const { hasFired, previousPos } = this.state;
+  const { hasFired, previousPosition } = this.state;
   const { duration } = event;
-  const position = Math.floor(event.position);
-  let hasChanged = false;
 
-  if (this.props.onEverySecond) {
-    if (position > previousPos) {
-      this.props.onEverySecond(position);
-    }
+  const durationInteger = Math.floor(duration);
+  const currentPositionInteger = Math.floor(event.position);
+  const previousPositionInteger = previousPosition || 0;
 
-    this.setState({ previousPos: position });
-  } else {
-    if (!hasFired.threeSeconds && position >= 3) {
-      this.props.onThreeSeconds();
-      hasFired.threeSeconds = true;
-      hasChanged = true;
-    }
+  let shouldUpdateState = false;
 
-    if (!hasFired.tenSeconds && position >= 10) {
-      this.props.onTenSeconds();
-      hasFired.tenSeconds = true;
-      hasChanged = true;
-    }
-
-    if (!hasFired.thirtySeconds && position >= 30) {
-      this.props.onThirtySeconds();
-      hasFired.thirtySeconds = true;
-      hasChanged = true;
-    }
+  if (currentPositionInteger === 0) {
+    shouldUpdateState = true;
   }
 
-  if (!hasFired.twentyFivePercent && ((position / duration) * 100) >= 25) {
-    this.props.onTwentyFivePercent();
-    hasFired.twentyFivePercent = true;
-    hasChanged = true;
+  if (currentPositionInteger > previousPositionInteger) {
+    this.props.onEverySecond(currentPositionInteger);
+    shouldUpdateState = true;
   }
 
-  if (!hasFired.fiftyPercent && ((position / duration) * 100) >= 50) {
+  if (!hasFired.threeSeconds && currentPositionInteger >= 3) {
+    this.props.onThreeSeconds();
+    hasFired.threeSeconds = true;
+    shouldUpdateState = true;
+  }
+
+  if (!hasFired.tenSeconds && currentPositionInteger >= 10) {
+    this.props.onTenSeconds();
+    hasFired.tenSeconds = true;
+    shouldUpdateState = true;
+  }
+
+  if (!hasFired.thirtySeconds && currentPositionInteger >= 30) {
+    this.props.onThirtySeconds();
+    hasFired.thirtySeconds = true;
+    shouldUpdateState = true;
+  }
+
+  if (!hasFired.fiftyPercent && ((currentPositionInteger / durationInteger) * 100) >= 50) {
     this.props.onFiftyPercent();
     hasFired.fiftyPercent = true;
-    hasChanged = true;
+    shouldUpdateState = true;
   }
 
-  if (!hasFired.seventyFivePercent && ((position / duration) * 100) >= 75) {
+  if (!hasFired.seventyFivePercent && (currentPositionInteger / durationInteger) * 100) >= 75) {
     this.props.onSeventyFivePercent();
     hasFired.seventyFivePercent = true;
     hasChanged = true;
   }
 
-  if (!hasFired.ninetyFivePercent && ((position / duration) * 100) >= 95) {
+  if (!hasFired.ninetyFivePercent && ((currentPositionInteger / durationInteger) * 100) >= 95) {
     this.props.onNinetyFivePercent();
     hasFired.ninetyFivePercent = true;
-    hasChanged = true;
+    shouldUpdateState = true;
   }
 
-  if (hasChanged) {
+  if (!hasFired.OneHundredPercent && currentPositionInteger === durationInteger) {
+    this.props.onOneHundredPercent();
+    hasFired.OneHundredPercent = true;
+    shouldUpdateState = true;
+  }
+
+  if (shouldUpdateState) {
     this.setState({
       hasFired,
+      previousPosition: currentPositionInteger,
     });
   }
 }

--- a/src/create-event-handlers/on-time.js
+++ b/src/create-event-handlers/on-time.js
@@ -1,45 +1,54 @@
 function onTime(event) {
-  const { hasFired } = this.state;
-  const { position, duration } = event;
+  const { hasFired, previousPos } = this.state;
+  const { duration } = event;
+  const position = Math.floor(event.position);
   let hasChanged = false;
 
-  if (!hasFired.threeSeconds && position > 3) {
+  if (this.props.onEverySecond) {
+    if (position > previousPos) {
+      this.props.onEverySecond(position);
+    }
+
+    this.setState({ previousPos: position });
+  }
+
+  if (!hasFired.threeSeconds && position >= 3) {
     this.props.onThreeSeconds();
     hasFired.threeSeconds = true;
     hasChanged = true;
   }
 
-  if (!hasFired.tenSeconds && position > 10) {
+  if (!hasFired.tenSeconds && position >= 10) {
     this.props.onTenSeconds();
     hasFired.tenSeconds = true;
     hasChanged = true;
   }
 
-  if (!hasFired.thirtySeconds && position > 30) {
+  if (!hasFired.thirtySeconds && position >= 30) {
     this.props.onThirtySeconds();
     hasFired.thirtySeconds = true;
     hasChanged = true;
   }
 
-  if (!hasFired.twentyFivePercent && ((position / duration) * 100) > 25) {
+  if (!hasFired.twentyFivePercent && ((position / duration) * 100) >= 25) {
     this.props.onTwentyFivePercent();
     hasFired.twentyFivePercent = true;
     hasChanged = true;
   }
 
-  if (!hasFired.fiftyPercent && ((position / duration) * 100) > 50) {
+  if (!hasFired.fiftyPercent && ((position / duration) * 100) >= 50) {
     this.props.onFiftyPercent();
     hasFired.fiftyPercent = true;
     hasChanged = true;
   }
 
-  if (!hasFired.seventyFivePercent && ((position / duration) * 100) > 75) {
+  if (!hasFired.seventyFivePercent && ((position / duration) * 100) >= 75) {
     this.props.onSeventyFivePercent();
     hasFired.seventyFivePercent = true;
     hasChanged = true;
   }
 
-  if (!hasFired.ninetyFivePercent && ((position / duration) * 100) > 95) {
+  if (!hasFired.ninetyFivePercent && ((position / duration) * 100) >= 95) {
     this.props.onNinetyFivePercent();
     hasFired.ninetyFivePercent = true;
     hasChanged = true;

--- a/src/helpers/initialize.js
+++ b/src/helpers/initialize.js
@@ -12,7 +12,7 @@ function initialize({ component, player, playerOpts }) {
   player.on('adPlay', component.eventHandlers.onAdPlay);
   player.on('adPause', component.props.onAdPause);
   player.on('adComplete', component.props.onAdComplete);
-  player.on('adTime', component.eventHandlers.onTime);
+  player.on('adTime', component.eventHandlers.onAdTime);
   player.on('fullscreen', component.eventHandlers.onFullScreen);
   player.on('pause', component.props.onPause);
   player.on('play', component.eventHandlers.onPlay);

--- a/src/helpers/initialize.js
+++ b/src/helpers/initialize.js
@@ -19,7 +19,6 @@ function initialize({ component, player, playerOpts }) {
   player.on('mute', component.eventHandlers.onMute);
   player.on('playlistItem', component.eventHandlers.onVideoLoad);
   player.on('time', component.eventHandlers.onTime);
-  player.on('beforeComplete', component.props.onOneHundredPercent);
 }
 
 export default initialize;

--- a/src/helpers/initialize.js
+++ b/src/helpers/initialize.js
@@ -11,6 +11,8 @@ function initialize({ component, player, playerOpts }) {
   player.on('error', component.eventHandlers.onError);
   player.on('adPlay', component.eventHandlers.onAdPlay);
   player.on('adPause', component.props.onAdPause);
+  player.on('adComplete', component.props.onAdComplete);
+  player.on('adTime', component.eventHandlers.onTime);
   player.on('fullscreen', component.eventHandlers.onFullScreen);
   player.on('pause', component.props.onPause);
   player.on('play', component.eventHandlers.onPlay);

--- a/src/helpers/initialize.js
+++ b/src/helpers/initialize.js
@@ -19,6 +19,7 @@ function initialize({ component, player, playerOpts }) {
   player.on('mute', component.eventHandlers.onMute);
   player.on('playlistItem', component.eventHandlers.onVideoLoad);
   player.on('time', component.eventHandlers.onTime);
+  player.on('beforeComplete', component.props.onOneHundredPercent);
 }
 
 export default initialize;

--- a/test/initialize.test.js
+++ b/test/initialize.test.js
@@ -132,5 +132,10 @@ test('initialize()', (t) => {
     'it sets the time event with the onTime() eventHandler',
   );
 
+  t.equal(
+    playerFunctions.beforeComplete, mockComponent.props.onOneHundredPercent,
+    'it sets the beforeComplete event with the onOneHundredPercent() prop',
+  );
+
   t.end();
 });

--- a/test/initialize.test.js
+++ b/test/initialize.test.js
@@ -73,18 +73,8 @@ test('initialize()', (t) => {
   );
 
   t.equal(
-    playerFunctions.adPause, mockComponent.props.onAdPause,
-    'it sets the adPause event with the onAdPause() prop',
-  );
-
-  t.equal(
     playerFunctions.pause, mockComponent.props.onPause,
     'it sets the pause event with the onPause() prop',
-  );
-
-  t.equal(
-    playerFunctions.beforeComplete, mockComponent.props.onOneHundredPercent,
-    'it sets the beforeComplete event with the onOneHundredPercent() prop',
   );
 
   t.equal(
@@ -100,6 +90,21 @@ test('initialize()', (t) => {
   t.equal(
     playerFunctions.adPlay, mockComponent.eventHandlers.onAdPlay,
     'it sets the adPlay event with the onAdPlay() eventHandler',
+  );
+
+  t.equal(
+    playerFunctions.adPause, mockComponent.props.onAdPause,
+    'it sets the adPause event with the onAdPause() prop',
+  );
+
+  t.equal(
+    playerFunctions.adComplete, mockComponent.props.onAdComplete,
+    'it sets the adComplete event with the onAdComplete() prop',
+  );
+
+  t.equal(
+    playerFunctions.adTime, mockComponent.eventHandlers.onTime,
+    'it sets the adTime event with the onTime() eventHandler',
   );
 
   t.equal(

--- a/test/initialize.test.js
+++ b/test/initialize.test.js
@@ -103,8 +103,8 @@ test('initialize()', (t) => {
   );
 
   t.equal(
-    playerFunctions.adTime, mockComponent.eventHandlers.onTime,
-    'it sets the adTime event with the onTime() eventHandler',
+    playerFunctions.adTime, mockComponent.eventHandlers.onAdTime,
+    'it sets the adTime event with the onAdTime() eventHandler',
   );
 
   t.equal(

--- a/test/on-ad-time.test.js
+++ b/test/on-ad-time.test.js
@@ -29,18 +29,18 @@ test('eventHandlers.onEverySecond() when video position is from 0 to 2', (t) => 
   const onAdTime = createEventHandlers(mockComponent).onAdTime;
 
   t.doesNotThrow(onAdTime.bind(null, mockEvent), 'it runs without error');
-  t.deepEqual(results.onEverySecondCallCount, 0, 'it does not invoke onEverySecond() prop on initial call');
+  t.deepEqual(results.onEverySecondCallCount, 1, 'it does invokes onEverySecond() prop on initial call');
 
   mockEvent.position = 1;
 
   t.doesNotThrow(onAdTime.bind(null, mockEvent), 'it runs without error one second later');
-  t.deepEqual(results.onEverySecondCallCount, 1, 'it invoke onEverySecond() prop at one second');
+  t.deepEqual(results.onEverySecondCallCount, 2, 'it invoke onEverySecond() prop at one second');
   t.deepEqual(mockComponent.state.previousPositionInteger, 1, 'stores 1 as previous position');
 
   mockEvent.position = 2;
 
   t.doesNotThrow(onAdTime.bind(null, mockEvent), 'it runs without error one second later');
-  t.deepEqual(results.onEverySecondCallCount, 2, 'it invoke onEverySecond() prop at two seconds');
+  t.deepEqual(results.onEverySecondCallCount, 3, 'it invoke onEverySecond() prop at two seconds');
   t.deepEqual(mockComponent.state.previousPositionInteger, 2, 'stores 2 as previous position');
 
   t.end();

--- a/test/on-ad-time.test.js
+++ b/test/on-ad-time.test.js
@@ -1,0 +1,47 @@
+import test from 'tape';
+import createEventHandlers from '../src/create-event-handlers';
+import MockComponent from './helpers/mock-component';
+
+function createMockComponent() {
+  const results = {
+    onEverySecondCallCount: 0,
+  };
+
+  return {
+    mockComponent: new MockComponent({
+      initialState: { },
+      onEverySecond(event) {
+        results.onEverySecondCallCount += 1;
+        results.onEverySecondArgs = event;
+      },
+    }),
+    results,
+  };
+}
+
+test('eventHandlers.onEverySecond() when video position is from 0 to 2', (t) => {
+  const { mockComponent, results } = createMockComponent();
+
+  const mockEvent = {
+    duration: 100,
+    position: 0,
+  };
+  const onAdTime = createEventHandlers(mockComponent).onAdTime;
+
+  t.doesNotThrow(onAdTime.bind(null, mockEvent), 'it runs without error');
+  t.deepEqual(results.onEverySecondCallCount, 0, 'it does not invoke onEverySecond() prop on initial call');
+
+  mockEvent.position = 1;
+
+  t.doesNotThrow(onAdTime.bind(null, mockEvent), 'it runs without error one second later');
+  t.deepEqual(results.onEverySecondCallCount, 1, 'it invoke onEverySecond() prop at one second');
+  t.deepEqual(mockComponent.state.previousPositionInteger, 1, 'stores 1 as previous position');
+
+  mockEvent.position = 2;
+
+  t.doesNotThrow(onAdTime.bind(null, mockEvent), 'it runs without error one second later');
+  t.deepEqual(results.onEverySecondCallCount, 2, 'it invoke onEverySecond() prop at two seconds');
+  t.deepEqual(mockComponent.state.previousPositionInteger, 2, 'stores 2 as previous position');
+
+  t.end();
+});

--- a/test/on-time.test.js
+++ b/test/on-time.test.js
@@ -501,18 +501,18 @@ test('eventHandlers.onEverySecond() when video position is from 0 to 2', (t) => 
   const onTime = createEventHandlers(mockComponent).onTime;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error');
-  t.deepEqual(results.onEverySecondCallCount, 0, 'it does not invoke onEverySecond() prop on initial call');
+  t.deepEqual(results.onEverySecondCallCount, 1, 'it invokes onEverySecond() prop on initial call');
 
   mockEvent.position = 1;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
-  t.deepEqual(results.onEverySecondCallCount, 1, 'it invoke onEverySecond() prop at one second');
+  t.deepEqual(results.onEverySecondCallCount, 2, 'it invoke onEverySecond() prop at one second');
   t.deepEqual(mockComponent.state.previousPositionInteger, 1, 'stores 1 as previous position');
 
   mockEvent.position = 2;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
-  t.deepEqual(results.onEverySecondCallCount, 2, 'it invoke onEverySecond() prop at two seconds');
+  t.deepEqual(results.onEverySecondCallCount, 3, 'it invoke onEverySecond() prop at two seconds');
   t.deepEqual(mockComponent.state.previousPositionInteger, 2, 'stores 2 as previous position');
 
   t.end();

--- a/test/on-time.test.js
+++ b/test/on-time.test.js
@@ -3,7 +3,9 @@ import createEventHandlers from '../src/create-event-handlers';
 import MockComponent from './helpers/mock-component';
 
 function createMockComponent() {
-  const results = {};
+  const results = {
+    onEverySecondCallCount: 0,
+  };
 
   return {
     mockComponent: new MockComponent({
@@ -41,7 +43,7 @@ function createMockComponent() {
         results.onOneHundredPercentArgs = event;
       },
       onEverySecond(event) {
-        results.onEverySecondCalled = true;
+        results.onEverySecondCallCount += 1;
         results.onEverySecondArgs = event;
       },
     }),
@@ -54,7 +56,7 @@ test('eventHandlers.onTime() when video position is less than 3', (t) => {
 
   const mockEvent = {
     duration: 100,
-    position: 2.9999,
+    position: 2,
   };
   const onTime = createEventHandlers(mockComponent).onTime;
 
@@ -105,7 +107,7 @@ test('eventHandlers.onTime() when video position is between 3 and 10', (t) => {
   mockEvent.position = 8;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
-  t.equal(mockComponent.state.hasFired, currentState.hasFired, 'hasFired in state does is not modified one second later');
+  t.equal(mockComponent.state.hasFired, currentState.hasFired, 'hasFired in state is not modified one second later');
   t.notOk(
     results.onThreeSecondsCalled,
     'it does not call the onThreeSeconds() prop a second time',
@@ -170,7 +172,7 @@ test('eventHandlers.onTime() when video position is between 10 and 30', (t) => {
   mockEvent.position = 12;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
-  t.equal(mockComponent.state.hasFired, currentState.hasFired, 'hasFired in state does is not modified one second later');
+  t.equal(mockComponent.state.hasFired, currentState.hasFired, 'hasFired in state is not modified one second later');
   t.notOk(
     results.onThreeSecondsCalled,
     'it does not call the onThreeSeconds() prop a second time',
@@ -239,7 +241,7 @@ test('eventHandlers.onTime() when video position is above 30 seconds', (t) => {
   mockEvent.position = 32;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
-  t.equal(mockComponent.state.hasFired, currentState.hasFired, 'hasFired in state does is not modified one second later');
+  t.equal(mockComponent.state.hasFired, currentState.hasFired, 'hasFired in state is not modified one second later');
   t.notOk(
     results.onThreeSecondsCalled,
     'it does not call the onThreeSeconds() prop a second time',
@@ -312,7 +314,7 @@ test('eventHandlers.onTime() when video position is above 50 and below 75', (t) 
   mockEvent.position = 52;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
-  t.equal(mockComponent.state.hasFired, currentState.hasFired, 'hasFired in state does is not modified one second later');
+  t.equal(mockComponent.state.hasFired, currentState.hasFired, 'hasFired in state is not modified one second later');
   t.notOk(
     results.onThreeSecondsCalled,
     'it does not call the onThreeSeconds() prop a second time',
@@ -460,7 +462,7 @@ test('eventHandlers.onTime() when video position is beyond ninety five percent',
   mockEvent.position = 97;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
-  t.equal(mockComponent.state.hasFired, currentState.hasFired, 'hasFired in state does is not modified one second later');
+  t.equal(mockComponent.state.hasFired, currentState.hasFired, 'hasFired in state is not modified one second later');
   t.notOk(
     results.onThreeSecondsCalled,
     'it does not call the onThreeSeconds() prop a second time',
@@ -489,6 +491,34 @@ test('eventHandlers.onTime() when video position is beyond ninety five percent',
     results.onNinetyFivePercentCalled,
     'it does not call the onNinetyFivePercent() prop a second time',
   );
+
+  t.end();
+});
+
+test('eventHandlers.onEverySecond() when video position is from 0 to 2', (t) => {
+  const { mockComponent, results } = createMockComponent();
+
+  const mockEvent = {
+    duration: 100,
+    position: 0,
+  };
+  const onTime = createEventHandlers(mockComponent).onTime;
+
+  t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error');
+  t.deepEqual(results.onEverySecondCallCount, 0, 'it does not invoke onEverySecond() prop on initial call');
+  t.deepEqual(mockComponent.state.previousPosition, 0, 'stores 0 as previous position');
+
+  mockEvent.position = 1;
+
+  t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
+  t.deepEqual(results.onEverySecondCallCount, 1, 'it invoke onEverySecond() prop at one second');
+  t.deepEqual(mockComponent.state.previousPosition, 1, 'stores 1 as previous position');
+
+  mockEvent.position = 2;
+
+  t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
+  t.deepEqual(results.onEverySecondCallCount, 2, 'it invoke onEverySecond() prop at two seconds');
+  t.deepEqual(mockComponent.state.previousPosition, 2, 'stores 2 as previous position');
 
   t.end();
 });

--- a/test/on-time.test.js
+++ b/test/on-time.test.js
@@ -348,7 +348,7 @@ test('eventHandlers.onTime() when video position is above 75', (t) => {
 
   const mockEvent = {
     duration: 100,
-    position: 76,
+    position: 77,
   };
   const onTime = createEventHandlers(mockComponent).onTime;
 

--- a/test/on-time.test.js
+++ b/test/on-time.test.js
@@ -38,10 +38,6 @@ function createMockComponent() {
         results.onNinetyFivePercentCalled = true;
         results.onNinetyFivePercentArgs = event;
       },
-      onOneHundredPercent(event) {
-        results.onOneHundredPercentCalled = true;
-        results.onOneHundredPercentArgs = event;
-      },
       onEverySecond(event) {
         results.onEverySecondCallCount += 1;
         results.onEverySecondArgs = event;
@@ -506,19 +502,18 @@ test('eventHandlers.onEverySecond() when video position is from 0 to 2', (t) => 
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error');
   t.deepEqual(results.onEverySecondCallCount, 0, 'it does not invoke onEverySecond() prop on initial call');
-  t.deepEqual(mockComponent.state.previousPosition, 0, 'stores 0 as previous position');
 
   mockEvent.position = 1;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
   t.deepEqual(results.onEverySecondCallCount, 1, 'it invoke onEverySecond() prop at one second');
-  t.deepEqual(mockComponent.state.previousPosition, 1, 'stores 1 as previous position');
+  t.deepEqual(mockComponent.state.previousPositionInteger, 1, 'stores 1 as previous position');
 
   mockEvent.position = 2;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
   t.deepEqual(results.onEverySecondCallCount, 2, 'it invoke onEverySecond() prop at two seconds');
-  t.deepEqual(mockComponent.state.previousPosition, 2, 'stores 2 as previous position');
+  t.deepEqual(mockComponent.state.previousPositionInteger, 2, 'stores 2 as previous position');
 
   t.end();
 });

--- a/test/on-time.test.js
+++ b/test/on-time.test.js
@@ -36,6 +36,14 @@ function createMockComponent() {
         results.onNinetyFivePercentCalled = true;
         results.onNinetyFivePercentArgs = event;
       },
+      onOneHundredPercent(event) {
+        results.onOneHundredPercentCalled = true;
+        results.onOneHundredPercentArgs = event;
+      },
+      onEverySecond(event) {
+        results.onEverySecondCalled = true;
+        results.onEverySecondArgs = event;
+      },
     }),
     results,
   };
@@ -46,7 +54,7 @@ test('eventHandlers.onTime() when video position is less than 3', (t) => {
 
   const mockEvent = {
     duration: 100,
-    position: 3,
+    position: 2.9999,
   };
   const onTime = createEventHandlers(mockComponent).onTime;
 
@@ -97,7 +105,7 @@ test('eventHandlers.onTime() when video position is between 3 and 10', (t) => {
   mockEvent.position = 8;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
-  t.equal(mockComponent.state, currentState, 'it does not change component state a second time');
+  t.equal(mockComponent.state.hasFired, currentState.hasFired, 'hasFired in state does is not modified one second later');
   t.notOk(
     results.onThreeSecondsCalled,
     'it does not call the onThreeSeconds() prop a second time',
@@ -162,7 +170,7 @@ test('eventHandlers.onTime() when video position is between 10 and 30', (t) => {
   mockEvent.position = 12;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
-  t.equal(mockComponent.state, currentState, 'it does not change component state a second time');
+  t.equal(mockComponent.state.hasFired, currentState.hasFired, 'hasFired in state does is not modified one second later');
   t.notOk(
     results.onThreeSecondsCalled,
     'it does not call the onThreeSeconds() prop a second time',
@@ -231,7 +239,7 @@ test('eventHandlers.onTime() when video position is above 30 seconds', (t) => {
   mockEvent.position = 32;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
-  t.equal(mockComponent.state, currentState, 'it does not change component state a second time');
+  t.equal(mockComponent.state.hasFired, currentState.hasFired, 'hasFired in state does is not modified one second later');
   t.notOk(
     results.onThreeSecondsCalled,
     'it does not call the onThreeSeconds() prop a second time',
@@ -304,7 +312,7 @@ test('eventHandlers.onTime() when video position is above 50 and below 75', (t) 
   mockEvent.position = 52;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
-  t.equal(mockComponent.state, currentState, 'it does not change component state a second time');
+  t.equal(mockComponent.state.hasFired, currentState.hasFired, 'hasFired in state does is not modified one second later');
   t.notOk(
     results.onThreeSecondsCalled,
     'it does not call the onThreeSeconds() prop a second time',
@@ -452,7 +460,7 @@ test('eventHandlers.onTime() when video position is beyond ninety five percent',
   mockEvent.position = 97;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
-  t.equal(mockComponent.state, currentState, 'it does not change component state a second time');
+  t.equal(mockComponent.state.hasFired, currentState.hasFired, 'hasFired in state does is not modified one second later');
   t.notOk(
     results.onThreeSecondsCalled,
     'it does not call the onThreeSeconds() prop a second time',


### PR DESCRIPTION
** WORK IN PROGRESS **

#### Ad event hook
* Accept `adComplete` in props.  Triggered when the ad playback completes -[jwplayer().on('adComplete')](https://developer.jwplayer.com/jw-player/docs/javascript-api-reference/#jwplayeronadcomplete)

#### Time event hook
* `onEverySecond` is passed in as props and is invoked approximately every one second.
* Due to the video position value being converted into an integer, it is not exactly 1 second.  If the JWPlayer triggers `onTime` at position 1.22, and the next `onTime` at position 2.11, `onEverySecond` will be triggered.  JWPlayer triggers the event approximately 4 times a second. 
* Ad playback now triggers time events.