### PR TITLE
[BUGFIX] - videos audio keeps playing when navigating a new page

### DIFF
--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -43,13 +43,20 @@ class ReactJWPlayer extends Component {
       existingScript.onload = getCurriedOnLoad(existingScript, this._initialize);
     }
   }
+
+  componentWillUnmount() {
+    if (this.player && this.player.remove) { this.player.remove(); }
+  }
+
   _initialize() {
     const component = this;
     const player = window.jwplayer(this.props.playerId);
+    this.player = player;
     const playerOpts = getPlayerOpts(this.props);
 
     initialize({ component, player, playerOpts });
   }
+
   render() {
     return (
       <div className={this.props.className} id={this.props.playerId} />

--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -59,7 +59,12 @@ class ReactJWPlayer extends Component {
 
   render() {
     return (
-      <div className={this.props.className} id={this.props.playerId} />
+      <div
+        className={this.props.className}
+        dangerouslySetInnerHTML={{
+          __html: `<div id="${this.props.playerId}"></div>`,
+        }}
+      />
     );
   }
 }


### PR DESCRIPTION
Testing this on our staging branch, we found that audio would keep playing when navigating
quickly from page to page that contain different players. This commit fixes that issue
and ensures the player removes itself inside of componentWillUnmount.

- BUGFIX: call remove to the player created to clean up events from jwplayer
- ADD: ComponentWillUnmount call