### PR TITLE
improved npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,5 @@
 node_modules
+.babelrc
+.travis.yml
+src
+test


### PR DESCRIPTION
Using your component with webpack result on this error:
```
ERROR in ./~/react-jw-player/dist/react-jw-player.js

Module build failed: Error: Couldn't find preset "es2015" relative to directory "/home/travis/build/coorpacademy/node_modules/react-jw-player"
```

This PR removes dev stuffs from npm distribution.