### PR TITLE
Render JW Player into an Un-Tracked Div in React

### DIFF
--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -52,7 +52,12 @@ class ReactJWPlayer extends Component {
   }
   render() {
     return (
-      <div className={this.props.className} id={this.props.playerId} />
+      <div
+        className={this.props.className}
+        dangerouslySetInnerHTML={{ // eslint-disable-line react/no-danger
+          __html: `<div id="${this.props.playerId}"></div>`,
+        }}
+      />
     );
   }
 }

--- a/test/react-jw-player.test.jsx
+++ b/test/react-jw-player.test.jsx
@@ -27,9 +27,10 @@ test('<ReactJWPlayer>', (t) => {
     'it renders a div as the root node',
   );
 
-  t.ok(
-    root.is(`#${testPlayerId}`),
-    'it gives the root div an id equal to the supplied playerId',
+  t.deepEqual(
+    root.props().dangerouslySetInnerHTML,
+    { __html: `<div id="${testPlayerId}"></div>` },
+    'it dangerously sets inner html to a div with the supplied id',
   );
 
   t.end();


### PR DESCRIPTION
Taken from this PR, but adding test coverage: https://github.com/micnews/react-jw-player/pull/16

There have been several complaints about server/client matching due to the nature of how JW Player handles the div that you inject it into. This PR solves that problem.