### PR TITLE
Add `onAdSkipped` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ import ReactJWPlayer from 'react-jw-player';
 const playlist = [{
   file: 'https://link-to-my-video.mp4',
   image: 'https://link-to-my-poster.jpg',
-  tracks: [{ 
-    file: 'https://link-to-subtitles.vtt', 
+  tracks: [{
+    file: 'https://link-to-subtitles.vtt',
     label: 'English',
     kind: 'captions',
-    'default': true 
+    'default': true
   }],
 },
 {
@@ -153,6 +153,12 @@ These are props that modify the basic behavior of the component.
       * This is the event object passed back from JW Player itself.
 * `onAdResume(event)`
   * A function that is run when the user resumes playing the preroll advertisement.
+  * Type: `function`
+  * Arguments:
+    * `event`
+      * This is the event object passed back from JW Player itself.
+* `onAdSkipped(event)`
+  * A function that is run when the user skips an advertisement.
   * Type: `function`
   * Arguments:
     * `event`

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -7,6 +7,7 @@ const defaultProps = {
   isMuted: false,
   onAdPlay: noOp,
   onAdResume: noOp,
+  onAdSkipped: noOp,
   onEnterFullScreen: noOp,
   onExitFullScreen: noOp,
   onMute: noOp,

--- a/src/helpers/initialize.js
+++ b/src/helpers/initialize.js
@@ -11,6 +11,7 @@ function initialize({ component, player, playerOpts }) {
   player.on('error', component.eventHandlers.onError);
   player.on('adPlay', component.eventHandlers.onAdPlay);
   player.on('adPause', component.props.onAdPause);
+  player.on('adSkipped', component.props.onAdSkipped);
   player.on('fullscreen', component.eventHandlers.onFullScreen);
   player.on('pause', component.props.onPause);
   player.on('play', component.eventHandlers.onPlay);

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -13,6 +13,7 @@ const propTypes = {
   onAdPause: PropTypes.func,
   onAdPlay: PropTypes.func,
   onAdResume: PropTypes.func,
+  onAdSkipped: PropTypes.func,
   onAutoStart: PropTypes.func,
   onEnterFullScreen: PropTypes.func,
   onError: PropTypes.func,

--- a/test/initialize.test.js
+++ b/test/initialize.test.js
@@ -27,6 +27,7 @@ test('initialize()', (t) => {
     },
     props: {
       onAdPause: 'onAdPause',
+      onAdSkipped: 'onAdSkipped',
       onOneHundredPercent: 'onOneHundredPercent',
       onPause: 'onPause',
       onReady: 'onReady',
@@ -75,6 +76,11 @@ test('initialize()', (t) => {
   t.equal(
     playerFunctions.adPause, mockComponent.props.onAdPause,
     'it sets the adPause event with the onAdPause() prop',
+  );
+
+  t.equal(
+    playerFunctions.adSkipped, mockComponent.props.onAdSkipped,
+    'it sets the adSkipped event with the onAdSkipped() prop',
   );
 
   t.equal(


### PR DESCRIPTION
This PR adds an `onAdSkipped` prop that takes a function that should run whenever the skip button is pressed on an ad.