### PR TITLE
Reconfigure Repo to Use Rollup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
-  "presets": ["es2015", "react"],
+  "presets": [
+    "es2015",
+    "react"
+  ],
   "plugins": ["transform-object-assign"]
 }

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,7 @@
 node_modules
-.babelrc
-.travis.yml
 src
 test
+.babelrc
+.gitignore
+.travis.yml
+rollup.config.js

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ import ReactJWPlayer from 'react-jw-player';
 const playlist = [{
   file: 'https://link-to-my-video.mp4',
   image: 'https://link-to-my-poster.jpg',
-  tracks: [{ 
-    file: 'https://link-to-subtitles.vtt', 
+  tracks: [{
+    file: 'https://link-to-subtitles.vtt',
     label: 'English',
     kind: 'captions',
-    'default': true 
+    'default': true
   }],
 },
 {
@@ -337,6 +337,4 @@ export default ReactJWPlayerContainer;
 
 ## Contributing
 
-**Just do it!**
-
-![shia](https://media.giphy.com/media/87xihBthJ1DkA/giphy.gif)
+Contributions are always welcome! Once you have the repo cloned, you can use `npm run watch` to build the code for development. Please make sure to add test coverage for any new or changed functionality. We will not merge untested code.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
     "react-dom": "^15.4.2",
     "react-test-renderer": "^15.4.2",
     "rollup": "^0.48.2",
+    "rollup-plugin-babel": "^3.0.2",
+    "rollup-plugin-commonjs": "^8.2.0",
+    "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-uglify": "^2.0.1",
     "snazzy": "^5.0.0",
     "tape": "^4.6.3"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A React component for launching JW Player instances on the client.",
   "main": "dist/react-jw-player.js",
   "scripts": {
-    "build": "babel src --out-dir dist",
+    "build": "rollup -c",
     "clean": "rm -rf dist",
     "lint": "miclint | snazzy",
     "prepublish": "npm run lint && npm run test && npm run clean && npm run build",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
     "jsdom-global": "^2.1.1",
     "miclint": "^4.1.0",
     "react-addons-test-utils": "^15.4.1",
-    "react-test-renderer": "^15.4.2",
     "react-dom": "^15.4.2",
+    "react-test-renderer": "^15.4.2",
+    "rollup": "^0.48.2",
     "snazzy": "^5.0.0",
     "tape": "^4.6.3"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,35 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import babel from 'rollup-plugin-babel';
+import commonjs from 'rollup-plugin-commonjs';
+import resolve from 'rollup-plugin-node-resolve';
+import uglify from 'rollup-plugin-uglify';
+
 export default {
   input: 'src/react-jw-player.jsx',
   output: {
-    file: 'dist/bundle.js',
+    file: 'dist/react-jw-player.js',
     format: 'umd',
   },
+  name: 'ReactJWPlayer',
+  external: ['react', 'prop-types'],
+  globals: {
+    react: 'React',
+    'prop-types': 'PropTypes',
+  },
+  plugins: [
+    resolve(),
+    commonjs({
+      include: 'node_modules/**',
+    }),
+    babel({
+      babelrc: false,
+      exclude: 'node_modules/**',
+      presets: [
+        ['es2015', { modules: false }],
+        'react',
+      ],
+      plugins: ['transform-object-assign'],
+    }),
+    uglify(),
+  ],
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,7 @@
+export default {
+  input: 'src/react-jw-player.jsx',
+  output: {
+    file: 'dist/bundle.js',
+    format: 'umd',
+  },
+};


### PR DESCRIPTION
This PR reconfigures the repo to use rollup for distribution, bringing the size of the distribution code down from 21k to 6k.

Babel is left in for use in development only.