### PR TITLE
Remove Player on Unmount

### DIFF
--- a/src/helpers/remove-jw-player-instance.js
+++ b/src/helpers/remove-jw-player-instance.js
@@ -1,0 +1,9 @@
+function removeJWPlayerInstance(playerId, context) {
+  const player = context.jwplayer && context.jwplayer(playerId);
+
+  if (player) {
+    player.remove();
+  }
+}
+
+export default removeJWPlayerInstance;

--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -5,6 +5,7 @@ import getCurriedOnLoad from './helpers/get-curried-on-load';
 import getPlayerOpts from './helpers/get-player-opts';
 import initialize from './helpers/initialize';
 import installPlayerScript from './helpers/install-player-script';
+import removeJWPlayerInstance from './helpers/remove-jw-player-instance';
 
 import defaultProps from './default-props';
 import propTypes from './prop-types';
@@ -51,6 +52,9 @@ class ReactJWPlayer extends Component {
   }
   componentDidUpdate() {
     this._initialize();
+  }
+  componentWillUnmount() {
+    removeJWPlayerInstance(this.props.playerId, window);
   }
   _initialize() {
     const component = this;

--- a/test/remove-jw-player-instance.test.js
+++ b/test/remove-jw-player-instance.test.js
@@ -1,0 +1,61 @@
+import test from 'tape';
+import removeJWPlayerInstance from '../src/helpers/remove-jw-player-instance';
+
+test('removeJWPlayerInstance() with active player', (t) => {
+  let requestedId;
+  let removeCalled;
+
+  const playerId = 'playerId';
+
+  const mockContext = {
+    jwplayer(id) {
+      requestedId = id;
+      return {
+        remove() {
+          removeCalled = true;
+        },
+      };
+    },
+  };
+
+  removeJWPlayerInstance(playerId, mockContext);
+
+  t.is(
+    requestedId,
+    playerId,
+    'it asks jwplayer for the player with the proper id',
+  );
+
+  t.ok(
+    removeCalled,
+    'it calls remove() on the components player property',
+  );
+
+  t.end();
+});
+
+test('removeJWPlayerInstance() with inactive player', (t) => {
+  let requestedId;
+
+  const playerId = 'playerId';
+
+  const mockContext = {
+    jwplayer(id) {
+      requestedId = id;
+      return null;
+    },
+  };
+
+  t.doesNotThrow(
+    () => removeJWPlayerInstance(playerId, mockContext),
+    'it runs without error',
+  );
+
+  t.is(
+    requestedId,
+    playerId,
+    'it asks jwplayer for the player with the proper id',
+  );
+
+  t.end();
+});


### PR DESCRIPTION
Taken from https://github.com/micnews/react-jw-player/pull/28 but added test coverage!

This PR removes the player on unmount, which prevents a bug in some implementations in which audio from one video can keep running after the video has left the page.