### PR TITLE
Advertising props

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ These are props that modify the basic behavior of the component.
   * Example: `https//content.jwplatform.com/feeds/abCD1234.json`
 
 ## Optional Configuration Props
+* `advertisingOptions`
+  * An optional object containing properties that will be added to JWplayer's advertising configuration. See the [JWPlayer Advertising Docs](https://developer.jwplayer.com/jw-player/docs/developer-guide/customization/configuration-reference/#advertising) for more info
+  * Type: `object`
 * `aspectRatio`
   * An optional aspect ratio to give the video player. Can be 'inherit', `1:1` or `16:9` currently.
   * Defaults to 'inherit'.

--- a/src/helpers/get-player-opts.js
+++ b/src/helpers/get-player-opts.js
@@ -1,5 +1,6 @@
 function getPlayerOpts(opts) {
   const {
+    advertisingOptions = {},
     aspectRatio,
     customProps = {},
     file,
@@ -32,11 +33,11 @@ function getPlayerOpts(opts) {
   }
 
   if (hasAdvertising) {
-    playerOpts.advertising = {
+    playerOpts.advertising = Object.assign({
       client: 'googima',
       admessage: 'Ad — xxs left',
       autoplayadsmuted: true,
-    };
+    }, advertisingOptions);
   }
 
   if (typeof isAutoPlay !== 'undefined') {

--- a/test/get-player-opts.test.js
+++ b/test/get-player-opts.test.js
@@ -91,6 +91,31 @@ test('getPlayerOpts() with advertising', (t) => {
   t.end();
 });
 
+test('getPlayerOpts() with custom advertising props', (t) => {
+  const mockPlaylist = 'mock playlist';
+
+  const actual = getPlayerOpts({
+    aspectRatio: '1:1',
+    generatePrerollUrl() {},
+    playlist: mockPlaylist,
+    advertisingOptions: {
+      client: 'vast',
+      vpaidcontrols: true,
+    },
+  });
+
+  t.equal(actual.aspectratio, '1:1', 'it sets the aspect ratio properly');
+  t.equal(actual.playlist, mockPlaylist, 'it sets the playlist property to the supplied playlist');
+  t.equal(actual.mute, false, 'it sets the mute property to false');
+  t.ok(actual.advertising, 'it sets advertising properties');
+  t.equal(actual.advertising.client, 'vast', 'it sets the advertising client');
+  t.equal(actual.advertising.admessage, 'Ad — xxs left', 'it sets the admessage');
+  t.ok(actual.advertising.autoplayadsmuted, 'it sets autoplayadsmuted to true');
+  t.ok(actual.advertising.vpaidcontrols, 'it sets vpaidcontrols to true');
+
+  t.end();
+});
+
 test('getPlayerOpts() with both a file and a playlist', (t) => {
   const mockFile = 'mock file';
   const mockPlaylist = 'mock playlist';


### PR DESCRIPTION
**UPDATE**: This is probably unnecessary cause of the `customProps` option

Adds ability to pass in custom advertising options to the player.

See Issue: https://github.com/micnews/react-jw-player/issues/46