### PR TITLE
Added inheritance of player config for isMuted and isAutoPlay

### DIFF
--- a/src/default-props.js
+++ b/src/default-props.js
@@ -3,8 +3,8 @@ const noOp = () => {};
 const defaultProps = {
   aspectRatio: 'inherit',
   file: '',
-  isAutoPlay: 'inherit',
-  isMuted: 'inherit',
+  isAutoPlay: undefined,
+  isMuted: undefined,
   onAdPlay: noOp,
   onAdResume: noOp,
   onAdSkipped: noOp,

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -3,8 +3,8 @@ const noOp = () => {};
 const defaultProps = {
   aspectRatio: 'inherit',
   file: '',
-  isAutoPlay: false,
-  isMuted: false,
+  isAutoPlay: 'inherit',
+  isMuted: 'inherit',
   onAdPlay: noOp,
   onAdResume: noOp,
   onAdSkipped: noOp,

--- a/src/helpers/get-player-opts.js
+++ b/src/helpers/get-player-opts.js
@@ -37,11 +37,11 @@ function getPlayerOpts(opts) {
     };
   }
 
-  if (typeof isAutoPlay !== 'undefined' && isAutoPlay !== 'inherit') {
+  if (typeof isAutoPlay !== 'undefined') {
     playerOpts.autostart = !!isAutoPlay;
   }
 
-  if (typeof isMuted !== 'undefined' && isMuted !== 'inherit') {
+  if (typeof isMuted !== 'undefined') {
     playerOpts.mute = !!isMuted;
   }
 

--- a/src/helpers/get-player-opts.js
+++ b/src/helpers/get-player-opts.js
@@ -13,9 +13,7 @@ function getPlayerOpts(opts) {
 
   const hasAdvertising = !!generatePrerollUrl;
 
-  const playerOpts = {
-    mute: !!isMuted,
-  };
+  const playerOpts = {};
 
   if (licenseKey) {
     playerOpts.key = licenseKey;
@@ -39,8 +37,12 @@ function getPlayerOpts(opts) {
     };
   }
 
-  if (typeof isAutoPlay !== 'undefined') {
+  if (typeof isAutoPlay !== 'undefined' && isAutoPlay !== 'inherit') {
     playerOpts.autostart = !!isAutoPlay;
+  }
+
+  if (typeof isMuted !== 'undefined' && isMuted !== 'inherit') {
+    playerOpts.mute = !!isMuted;
   }
 
   if (image) {

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -7,12 +7,8 @@ const propTypes = {
   file: PropTypes.string,
   generatePrerollUrl: PropTypes.func,
   image: PropTypes.string,
-  isAutoPlay: PropTypes.oneOfType([
-    PropTypes.bool,
-  ]),
-  isMuted: PropTypes.oneOfType([
-    PropTypes.bool,
-  ]),
+  isAutoPlay: PropTypes.bool,
+  isMuted: PropTypes.bool,
   licenseKey: PropTypes.string,
   onAdPause: PropTypes.func,
   onAdPlay: PropTypes.func,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -7,8 +7,12 @@ const propTypes = {
   file: PropTypes.string,
   generatePrerollUrl: PropTypes.func,
   image: PropTypes.string,
-  isAutoPlay: PropTypes.bool,
-  isMuted: PropTypes.bool,
+  isAutoPlay: PropTypes.oneOfType([
+    PropTypes.bool,
+  ]),
+  isMuted: PropTypes.oneOfType([
+    PropTypes.bool,
+  ]),
   licenseKey: PropTypes.string,
   onAdPause: PropTypes.func,
   onAdPlay: PropTypes.func,

--- a/test/get-player-opts.test.js
+++ b/test/get-player-opts.test.js
@@ -9,7 +9,7 @@ test('getPlayerOpts() with defaults', (t) => {
   });
 
   t.equal(actual.playlist, mockPlaylist, 'it sets the playlist property to the supplied playlist');
-  t.equal(actual.mute, false, 'it sets the mute property to false');
+  t.equal(actual.mute, undefined, 'it sets the mute property to undefined');
   t.notOk(
     Object.prototype.hasOwnProperty.call(actual, 'aspectratio'),
     'it does not set aspectratio properties',
@@ -82,7 +82,7 @@ test('getPlayerOpts() with advertising', (t) => {
 
   t.equal(actual.aspectratio, '1:1', 'it sets the aspect ratio properly');
   t.equal(actual.playlist, mockPlaylist, 'it sets the playlist property to the supplied playlist');
-  t.equal(actual.mute, false, 'it sets the mute property to false');
+  t.equal(actual.mute, undefined, 'it sets the mute property to undefined');
   t.ok(actual.advertising, 'it sets advertising properties');
   t.equal(actual.advertising.client, 'googima', 'it sets the advertising client');
   t.equal(actual.advertising.admessage, 'Ad — xxs left', 'it sets the admessage');


### PR DESCRIPTION
Many times you want to inherit the mute and autostart properties from your player, as they are both configured on it.
Previously to this PR, this component defaulted both to `false`, which was overriding the configuration set on the player.
It is still possible to override player setup by passing a concrete value of `true` or `false` in the `ReactJWPlayer` component's `isMuted` and `isAutoPlay` props.