### PR TITLE
Do not re-initialize an un-initialized component

### DIFF
--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -51,7 +51,9 @@ class ReactJWPlayer extends Component {
     return hasFileChanged || hasPlaylistChanged;
   }
   componentDidUpdate() {
-    this._initialize();
+    if (window.jwplayer && window.jwplayer(this.props.playerId)) {
+      this._initialize();
+    }
   }
   componentWillUnmount() {
     removeJWPlayerInstance(this.props.playerId, window);

--- a/test/react-jw-player.browser-test.js
+++ b/test/react-jw-player.browser-test.js
@@ -89,3 +89,42 @@ test('<ReactJWPlayer> when jwplayer script is present', (t) => {
 
   t.end();
 });
+
+test('<ReactJWPlayer> componentDidUpdate()', (t) => {
+  let initializeDidRun;
+
+  const componentDidUpdate = new ReactJWPlayer().componentDidUpdate.bind({
+    props: {
+      playerId: 'foobar',
+    },
+    _initialize: () => { initializeDidRun = true; },
+  });
+
+  if (window.jwplayer) {
+    delete window.jwplayer;
+  }
+
+  t.doesNotThrow(
+    () => componentDidUpdate(),
+    'it runs without error when jwplayer has not initialized',
+  );
+
+  t.notOk(
+    initializeDidRun,
+    'it does not call this._initialize() when jwplayer has not initialized yet',
+  );
+
+  global.window.jwplayer = () => 'jwplayer';
+
+  t.doesNotThrow(
+    () => componentDidUpdate(),
+    'it runs without error when jwplayer has initialized',
+  );
+
+  t.ok(
+    initializeDidRun,
+    'it does call this._initialize() when jwplayer has not initialized yet',
+  );
+
+  t.end();
+});


### PR DESCRIPTION
There is a bug where if you quickly change props before jwplayer initializes, the component crashes at the attempt to re-initialize. This prevents that.