### PR TITLE
Adding .onTime event that maps to jwPlayers own on('time') event.

### DIFF
--- a/src/create-event-handlers/on-time.js
+++ b/src/create-event-handlers/on-time.js
@@ -3,6 +3,8 @@ function onTime(event) {
   const { position, duration } = event;
   let hasChanged = false;
 
+  this.props.onTime(event);
+
   if (!hasFired.threeSeconds && position > 3) {
     this.props.onThreeSeconds();
     hasFired.threeSeconds = true;

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -29,6 +29,7 @@ const defaultProps = {
   onFiftyPercent: noOp,
   onSeventyFivePercent: noOp,
   onNinetyFivePercent: noOp,
+  onTime: noOp,
   playlist: '',
 };
 

--- a/test/on-time.test.js
+++ b/test/on-time.test.js
@@ -3,11 +3,15 @@ import createEventHandlers from '../src/create-event-handlers';
 import MockComponent from './helpers/mock-component';
 
 function createMockComponent() {
-  const results = {};
+  const results = { };
 
   return {
     mockComponent: new MockComponent({
       initialState: { hasFired: {} },
+      onTime(event) {
+        results.onTimeCalled = true;
+        results.onTimeArgs = event;
+      },
       onThreeSeconds(event) {
         results.onThreeSecondsCalled = true;
         results.onThreeSecondsArgs = event;
@@ -56,6 +60,8 @@ test('eventHandlers.onTime() when video position is less than 3', (t) => {
     {},
     'it does not add any events into component state hasFired object',
   );
+  t.ok(results.onTimeCalled, 'it calls the onTime() prop');
+  t.deepEqual(results.onTimeArgs, mockEvent, 'it calls the onTime() prop with correct arguments');
   t.notOk(results.onThreeSecondsCalled, 'it does not call the onThreeSeconds() prop');
   t.notOk(results.onTenSecondsCalled, 'it does not call the onTenSeconds() prop');
   t.notOk(results.onThirtySecondsCalled, 'it does not call the onThirtySeconds() prop');
@@ -84,6 +90,8 @@ test('eventHandlers.onTime() when video position is between 3 and 10', (t) => {
     },
     'it adds the proper events into component state hasFired object',
   );
+  t.ok(results.onTimeCalled, 'it calls the onTime() prop');
+  t.deepEqual(results.onTimeArgs, mockEvent, 'it calls the onTime() prop with correct arguments');
   t.ok(results.onThreeSecondsCalled, 'it calls the onThreeSeconds() prop');
   t.notOk(results.onTenSecondsCalled, 'it does not call the onTenSeconds() prop');
   t.notOk(results.onThirtySecondsCalled, 'it does not call the onThirtySeconds() prop');
@@ -93,11 +101,14 @@ test('eventHandlers.onTime() when video position is between 3 and 10', (t) => {
   t.notOk(results.onNinetyFivePercentCalled, 'it does not call the onNinetyFivePercent() prop');
 
   results.onThreeSecondsCalled = false;
+  results.onTimeCalled = false;
   const currentState = mockComponent.state;
   mockEvent.position = 8;
 
   t.doesNotThrow(onTime.bind(null, mockEvent), 'it runs without error one second later');
   t.equal(mockComponent.state, currentState, 'it does not change component state a second time');
+  t.ok(results.onTimeCalled, 'it calls the onTime() prop a second time');
+  t.deepEqual(results.onTimeArgs, mockEvent, 'it calls the onTime() prop with correct arguments');
   t.notOk(
     results.onThreeSecondsCalled,
     'it does not call the onThreeSeconds() prop a second time',


### PR DESCRIPTION
Type: Minor 

I know https://github.com/micnews/react-jw-player/issues/54 is in the works, but for some things I'm working on right now having the onTime event handler that maps to the jwplayer own on('time') event just makes things so much easier, and I realized that adding it like this wasn't a big task. 

But @danmakenoise let me know if you think this makes sense or not!