### PR TITLE
Add buffer callbacks

### DIFF
--- a/src/default-props.js
+++ b/src/default-props.js
@@ -30,6 +30,8 @@ const defaultProps = {
   onSeventyFivePercent: noOp,
   onNinetyFivePercent: noOp,
   onTime: noOp,
+  onBuffer: noOp,
+  onBufferChange: noOp,
   playlist: '',
 };
 

--- a/src/helpers/initialize.js
+++ b/src/helpers/initialize.js
@@ -19,6 +19,8 @@ function initialize({ component, player, playerOpts }) {
   player.on('playlistItem', component.eventHandlers.onVideoLoad);
   player.on('time', component.eventHandlers.onTime);
   player.on('beforeComplete', component.props.onOneHundredPercent);
+  player.on('buffer', component.props.onBuffer);
+  player.on('bufferChange', component.props.onBufferChange);
 }
 
 export default initialize;

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -33,6 +33,8 @@ const propTypes = {
   onTwentyFivePercent: PropTypes.func,
   onUnmute: PropTypes.func,
   onVideoLoad: PropTypes.func,
+  onBuffer: PropTypes.func,
+  onBufferChange: PropTypes.func,
   playerId: PropTypes.string.isRequired,
   playerScript: PropTypes.string.isRequired,
   playlist: PropTypes.oneOfType([

--- a/test/initialize.test.js
+++ b/test/initialize.test.js
@@ -31,6 +31,8 @@ test('initialize()', (t) => {
       onOneHundredPercent: 'onOneHundredPercent',
       onPause: 'onPause',
       onReady: 'onReady',
+      onBuffer: 'onBuffer',
+      onBufferChange: 'onBufferChange',
     },
   };
 
@@ -131,6 +133,16 @@ test('initialize()', (t) => {
   t.equal(
     playerFunctions.time, mockComponent.eventHandlers.onTime,
     'it sets the time event with the onTime() eventHandler',
+  );
+
+  t.equal(
+    playerFunctions.buffer, mockComponent.props.onBuffer,
+    'it sets the time event with the onBuffer() eventHandler',
+  );
+
+  t.equal(
+    playerFunctions.bufferChange, mockComponent.props.onBufferChange,
+    'it sets the time event with the onBufferChange() eventHandler',
   );
 
   t.end();


### PR DESCRIPTION
Type: Minor

Add callbacks for `buffer` and `bufferChange` events. Nothing special going on with those, just callbacking whenever they are triggered from the player, so didn't add any tests for it as I felt that was unnecessary. But let me know if you disagree and/or have any ideas for how to test this properly!