### PR TITLE
Added missing adComplete event hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ These are props that modify the basic behavior of the component.
   * Arguments:
     * `event`
       * This is the event object passed back from JW Player itself.
+* `onAdComplete(event)`
+  * A function that is run when an ad has finished playing.
+  * Type: `function`
+  * Arguments:
+    * `event`
+      * This is the event object passed back from JW Player itself.
 
 ## Optional Player Event Hook Props
 * `onAutoStart(event)`

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -8,6 +8,7 @@ const defaultProps = {
   onAdPlay: noOp,
   onAdResume: noOp,
   onAdSkipped: noOp,
+  onAdComplete: noOp,
   onEnterFullScreen: noOp,
   onExitFullScreen: noOp,
   onMute: noOp,

--- a/src/helpers/initialize.js
+++ b/src/helpers/initialize.js
@@ -12,6 +12,7 @@ function initialize({ component, player, playerOpts }) {
   player.on('adPlay', component.eventHandlers.onAdPlay);
   player.on('adPause', component.props.onAdPause);
   player.on('adSkipped', component.props.onAdSkipped);
+  player.on('adComplete', component.props.onAdComplete);
   player.on('fullscreen', component.eventHandlers.onFullScreen);
   player.on('pause', component.props.onPause);
   player.on('play', component.eventHandlers.onPlay);

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -14,6 +14,7 @@ const propTypes = {
   onAdPlay: PropTypes.func,
   onAdResume: PropTypes.func,
   onAdSkipped: PropTypes.func,
+  onAdComplete: PropTypes.func,
   onAutoStart: PropTypes.func,
   onEnterFullScreen: PropTypes.func,
   onError: PropTypes.func,

--- a/test/initialize.test.js
+++ b/test/initialize.test.js
@@ -28,6 +28,7 @@ test('initialize()', (t) => {
     props: {
       onAdPause: 'onAdPause',
       onAdSkipped: 'onAdSkipped',
+      onAdComplete: 'onAdComplete',
       onOneHundredPercent: 'onOneHundredPercent',
       onPause: 'onPause',
       onReady: 'onReady',
@@ -83,6 +84,11 @@ test('initialize()', (t) => {
   t.equal(
     playerFunctions.adSkipped, mockComponent.props.onAdSkipped,
     'it sets the adSkipped event with the onAdSkipped() prop',
+  );
+
+  t.equal(
+    playerFunctions.adComplete, mockComponent.props.onAdComplete,
+    'it sets the adComplete event with the onAdComplete() prop',
   );
 
   t.equal(


### PR DESCRIPTION
I have notices that the adComplete hook was missing. This PR adds it, as well as tests for it and a Read.me entry