### PR TITLE
Allow onError to be passed through as a prop to error events

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,12 @@ These are props that modify the basic behavior of the component.
   * Arguments:
     * `event`
       * This is the event object passed back from JW Player itself.
+* `onSetupError(event)`
+  * A function that is run when the player errors during setup.
+  * Type: `function`
+  * Arguments:
+    * `event`
+      * This is the event object passed back from JW Player itself.
 * `onTime(event)`
   * A function that is run whenever the playback position gets updated.
   * Type: `function`

--- a/src/helpers/initialize.js
+++ b/src/helpers/initialize.js
@@ -7,7 +7,7 @@ function initialize({ component, player, playerOpts }) {
 
   player.on('beforePlay', _onBeforePlay);
   player.on('ready', component.props.onReady);
-  player.on('setupError', component.props.onError);
+  player.on('setupError', component.props.onSetupError);
   player.on('error', component.props.onError);
   player.on('adPlay', component.eventHandlers.onAdPlay);
   player.on('adPause', component.props.onAdPause);

--- a/src/helpers/initialize.js
+++ b/src/helpers/initialize.js
@@ -7,8 +7,8 @@ function initialize({ component, player, playerOpts }) {
 
   player.on('beforePlay', _onBeforePlay);
   player.on('ready', component.props.onReady);
-  player.on('setupError', component.eventHandlers.onError);
-  player.on('error', component.eventHandlers.onError);
+  player.on('setupError', component.props.onError);
+  player.on('error', component.props.onError);
   player.on('adPlay', component.eventHandlers.onAdPlay);
   player.on('adPause', component.props.onAdPause);
   player.on('adSkipped', component.props.onAdSkipped);

--- a/test/initialize.test.js
+++ b/test/initialize.test.js
@@ -34,6 +34,7 @@ test('initialize()', (t) => {
       onError: 'onError',
       onBuffer: 'onBuffer',
       onBufferChange: 'onBufferChange',
+      onSetupError: 'onSetupError',
     },
   };
 
@@ -102,7 +103,7 @@ test('initialize()', (t) => {
   );
 
   t.equal(
-    playerFunctions.setupError, mockComponent.props.onError,
+    playerFunctions.setupError, mockComponent.props.onSetupError,
     'it sets the setupError event with the onError() prop',
   );
 

--- a/test/initialize.test.js
+++ b/test/initialize.test.js
@@ -18,7 +18,6 @@ test('initialize()', (t) => {
         onBeforePlayPlayer = player;
       },
       onAdPlay: 'onAdPlay',
-      onError: 'onError',
       onFullScreen: 'onFullScreen',
       onPlay: 'onPlay',
       onMute: 'onMute',
@@ -32,6 +31,7 @@ test('initialize()', (t) => {
       onOneHundredPercent: 'onOneHundredPercent',
       onPause: 'onPause',
       onReady: 'onReady',
+      onError: 'onError',
       onBuffer: 'onBuffer',
       onBufferChange: 'onBufferChange',
     },
@@ -102,13 +102,13 @@ test('initialize()', (t) => {
   );
 
   t.equal(
-    playerFunctions.setupError, mockComponent.eventHandlers.onError,
-    'it sets the setupError event with the onError() eventHandler',
+    playerFunctions.setupError, mockComponent.props.onError,
+    'it sets the setupError event with the onError() prop',
   );
 
   t.equal(
-    playerFunctions.error, mockComponent.eventHandlers.onError,
-    'it sets the error event with the onError() eventHandler',
+    playerFunctions.error, mockComponent.props.onError,
+    'it sets the error event with the onError() prop',
   );
 
   t.equal(


### PR DESCRIPTION
This PR resolves https://github.com/micnews/react-jw-player/issues/85, as well as implements the changes we requested in https://github.com/micnews/react-jw-player/pull/64 and https://github.com/micnews/react-jw-player/pull/66.

It turns out we were never passing an `onError` event handler on down. So, I switched it to a prop. Now users can do `onError={myErrorHandler}` and capture both setup errors, and normal errors.

I see no reason to distinguish between those error types until someone finds that absolutely necessary. (I don't believe at Mic we were ever interested in distinguishing those events)