### PR TITLE
Allow Dynamic Event Props

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   * [Required Props](#required-props)
   * Optional Props
     * [Configuration](#optional-configuration-props)
-    * Event Hooks
+    * [Event Hooks](#event-hooks)
       * [Advertising](#optional-advertising-event-hook-props)
       * [Player Events](#optional-player-event-hook-props)
       * [Time Events](#optional-time-event-hook-props)
@@ -140,6 +140,16 @@ These are props that modify the basic behavior of the component.
 * `useMultiplePlayerScripts`
   * EXPERIMENTAL - Allows you to load multiple player scripts and still load the proper configuration. Expect bugs, but report them!
   * Type: `boolean`
+
+# Event Hooks
+
+`react-jw-player` dynamically supports all events in JW Player. Simply preface the event name with `on` and pass it in as a prop.
+
+Examples:
+* `ready` => `onReady`
+* `setupError` => `onSetupError`
+
+`react-jw-player` has layered some different functionality on some of these events, so please check the docs below if you find any unexpected behavior!
 
 ## Optional Advertising Event Hook Props
 * `onAdPause(event)`

--- a/src/helpers/get-event-name-from-prop.js
+++ b/src/helpers/get-event-name-from-prop.js
@@ -1,0 +1,14 @@
+const getEventNameFromProp = (prop) => {
+  const beginsWithOn = prop.slice(0, 2) === 'on';
+
+  if (beginsWithOn) {
+    const eventName = prop.slice(2);
+    const [firstLetter, ...rest] = eventName;
+
+    return `${firstLetter.toLowerCase()}${rest.join('')}`;
+  }
+
+  return null;
+};
+
+export default getEventNameFromProp;

--- a/src/helpers/initialize.js
+++ b/src/helpers/initialize.js
@@ -1,3 +1,5 @@
+import getEventNameFromProp from './get-event-name-from-prop';
+
 function initialize({ component, player, playerOpts }) {
   function _onBeforePlay(event) {
     component.eventHandlers.onBeforePlay(event, player);
@@ -5,23 +7,28 @@ function initialize({ component, player, playerOpts }) {
 
   player.setup(playerOpts);
 
-  player.on('beforePlay', _onBeforePlay);
-  player.on('ready', component.props.onReady);
-  player.on('setupError', component.props.onSetupError);
-  player.on('error', component.props.onError);
-  player.on('adPlay', component.eventHandlers.onAdPlay);
-  player.on('adPause', component.props.onAdPause);
-  player.on('adSkipped', component.props.onAdSkipped);
-  player.on('adComplete', component.props.onAdComplete);
-  player.on('fullscreen', component.eventHandlers.onFullScreen);
-  player.on('pause', component.props.onPause);
-  player.on('play', component.eventHandlers.onPlay);
-  player.on('mute', component.eventHandlers.onMute);
-  player.on('playlistItem', component.eventHandlers.onVideoLoad);
-  player.on('time', component.eventHandlers.onTime);
-  player.on('beforeComplete', component.props.onOneHundredPercent);
-  player.on('buffer', component.props.onBuffer);
-  player.on('bufferChange', component.props.onBufferChange);
+  const eventsToInitialize = {};
+
+  Object.keys(component.props).forEach((prop) => {
+    const eventName = getEventNameFromProp(prop);
+
+    if (eventName) {
+      eventsToInitialize[eventName] = component.props[prop];
+    }
+  });
+
+  eventsToInitialize.adPlay = component.eventHandlers.onAdPlay;
+  eventsToInitialize.beforeComplete = component.props.onOneHundredPercent;
+  eventsToInitialize.beforePlay = _onBeforePlay;
+  eventsToInitialize.fullscreen = component.eventHandlers.onFullScreen;
+  eventsToInitialize.mute = component.eventHandlers.onMute;
+  eventsToInitialize.play = component.eventHandlers.onPlay;
+  eventsToInitialize.playlistItem = component.eventHandlers.onVideoLoad;
+  eventsToInitialize.time = component.eventHandlers.onTime;
+
+  Object.keys(eventsToInitialize).forEach((event) => {
+    player.on(event, eventsToInitialize[event]);
+  });
 }
 
 export default initialize;

--- a/test/get-event-name-from-prop.test.js
+++ b/test/get-event-name-from-prop.test.js
@@ -1,0 +1,37 @@
+import test from 'tape';
+
+import getEventNameFromProp from '../src/helpers/get-event-name-from-prop';
+
+test('getEventNameFromProp()', (t) => {
+  t.is(
+    typeof getEventNameFromProp,
+    'function',
+    'it is a function',
+  );
+
+  t.is(
+    getEventNameFromProp('playlist'),
+    null,
+    'it returns an null when the prop name is not for an event handler',
+  );
+
+  t.is(
+    getEventNameFromProp('onReady'),
+    'ready',
+    'it returns the proper event name for a single word event',
+  );
+
+  t.is(
+    getEventNameFromProp('onSetupError'),
+    'setupError',
+    'it returns the proper event name for a two word event',
+  );
+
+  t.is(
+    getEventNameFromProp('onPlaybackRateChanged'),
+    'playbackRateChanged',
+    'it returns the proper event name for a three word event',
+  );
+
+  t.end();
+});


### PR DESCRIPTION
Currently, we have to explicitly add event props to the library if we want the component to correctly assign props to JW Player events. This means that whenever JW Player changes props, we need to change our code, too. A better solution is to dynamically take all props named `onFoobar` and setup them up with JW Player through `player.on('foobar', props.onFoobar)`. 

This code accomplishes that while maintaining the event hooks _we_ created, like `onUnmute`, as well as maintaining functionality we had patched, like that for `onPlay`.

This should prevent us from needing to modify the code anytime a user requests a new event handler be added!

We naively take all props that begin with `on` and apply them as events to JW Player. This puts the onus on users to match the API, but should be worth it, IMO.

Curious for thoughts!