### PR TITLE
Fix preroll running twice

### DIFF
--- a/src/create-event-handlers/on-before-play.js
+++ b/src/create-event-handlers/on-before-play.js
@@ -1,7 +1,7 @@
 function onBeforePlay(event, player) {
   const currentVideo = player.getPlaylistItem();
 
-  if (!this.state.hasPlayed && typeof this.props.generatePrerollUrl === 'function') {
+  if (!this.state.hasPlayed && !this.state.adHasPlayed && typeof this.props.generatePrerollUrl === 'function') {
     player.playAd(this.props.generatePrerollUrl(currentVideo));
   }
 }

--- a/test/on-before-play.test.js
+++ b/test/on-before-play.test.js
@@ -80,6 +80,38 @@ test('eventHandlers.onBeforePlay() with preroll prop and player has played', (t)
   t.end();
 });
 
+test('eventHandlers.onBeforePlay() with preroll prop and player has not played but ad has player', (t) => {
+  let generatePrerollUrlCalled = false;
+  let playAdCalled = false;
+
+  const mockCurrentVideo = 'i am the current video';
+
+  const mockComponent = new MockComponent({
+    initialState: { hasPlayed: false, adHasPlayed: true },
+    generatePrerollUrl() {
+      generatePrerollUrlCalled = true;
+    },
+  });
+
+  const mockJWPlayerInstance = {
+    getPlaylistItem() {
+      return mockCurrentVideo;
+    },
+    playAd() {
+      playAdCalled = true;
+    },
+  };
+
+  const mockEvent = 'event';
+  const onBeforePlay = createEventHandlers(mockComponent).onBeforePlay;
+
+  t.doesNotThrow(onBeforePlay.bind(null, mockEvent, mockJWPlayerInstance), 'it runs without error');
+  t.notOk(generatePrerollUrlCalled, 'it does not call the supplied generatePrerollUrl() prop');
+  t.notOk(playAdCalled, 'it does not call playAd() on the supplied player instance');
+
+  t.end();
+});
+
 test('eventHandlers.onBeforePlay() without preroll prop and player has not played', (t) => {
   let playAdCalled = false;
 


### PR DESCRIPTION
Having an issue where preroll is being played twice. While debugging I noticed that onPlay was not being called on the first preroll, so .hasPlayed is still set to false in onBeforePlay. Also checking if the ad has played before playing ad fixes the issue!