### PR TITLE
deep comparison for playlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
   "peerDependencies": {
     "prop-types": "^15.5.10",
     "react": "^15.4.1 || ^16.0.0"
+  },
+  "dependencies": {
+    "react-fast-compare": "^2.0.1"
   }
 }

--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import isEqual from 'react-fast-compare';
 
 import createEventHandlers from './create-event-handlers';
 import getCurriedOnLoad from './helpers/get-curried-on-load';
@@ -58,7 +59,7 @@ class ReactJWPlayer extends Component {
   }
   shouldComponentUpdate(nextProps) {
     const hasFileChanged = this.props.file !== nextProps.file;
-    const hasPlaylistChanged = this.props.playlist !== nextProps.playlist;
+    const hasPlaylistChanged = !isEqual(this.props.playlist, nextProps.playlist);
 
     return hasFileChanged || hasPlaylistChanged;
   }


### PR DESCRIPTION
we are regenerating a playlist via redux that ends up being identical contents, just a fresh object. 

seems reasonable to do a deep comparison here, instead of a shallow equality test.

otherwise this code resets the player mid stream for us if that playlist prop gets touched.