### PR TITLE
Fix for on resume event

### DIFF
--- a/src/create-event-handlers/on-play.js
+++ b/src/create-event-handlers/on-play.js
@@ -4,7 +4,7 @@ function onPlay(event) {
       hasPlayed: true,
     });
     this.props.onAutoStart(event);
-  } else if (this.state.hasPlayed && event.oldstate === 'paused') {
+  } else if (this.state.hasPlayed && event.oldstate === 'buffering') {
     this.props.onResume(event);
   } else {
     this.props.onPlay(event);

--- a/src/create-event-handlers/on-play.js
+++ b/src/create-event-handlers/on-play.js
@@ -4,7 +4,7 @@ function onPlay(event) {
       hasPlayed: true,
     });
     this.props.onAutoStart(event);
-  } else if (this.state.hasPlayed && event.oldstate === 'buffering') {
+  } else if (this.state.hasPlayed && (event.oldstate === 'buffering' || event.oldstate === 'paused')) {
     this.props.onResume(event);
   } else {
     this.props.onPlay(event);

--- a/test/on-play.test.js
+++ b/test/on-play.test.js
@@ -35,7 +35,40 @@ test('eventHandlers.onPlay() when event.playReason is autostart', (t) => {
   t.end();
 });
 
-test('eventHandlers.onPlay() when video has played before and is currently paused', (t) => {
+test('eventHandlers.onPlay() when video has played before and is currently paused for version 7 and lower', (t) => {
+  let onAutoStartCalled = false;
+  let onPlayCalled = false;
+  let onResumeCalled = false;
+  let onResumeArgs;
+
+  const mockComponent = new MockComponent({
+    initialState: { hasPlayed: true },
+    onAutoStart() {
+      onAutoStartCalled = true;
+    },
+    onPlay() {
+      onPlayCalled = true;
+    },
+    onResume(event) {
+      onResumeCalled = true;
+      onResumeArgs = event;
+    },
+  });
+
+  const mockEvent = { oldstate: 'buffering' };
+  const onPlay = createEventHandlers(mockComponent).onPlay;
+
+  t.doesNotThrow(onPlay.bind(null, mockEvent), 'it runs without error');
+  t.ok(onResumeCalled, 'it calls the supplied onResume() prop');
+  t.notOk(onPlayCalled, 'it does not call onPlay()');
+  t.notOk(onAutoStartCalled, 'it does not call onAutoStart()');
+  t.equal(onResumeArgs, mockEvent, 'it passes the event to onResume()');
+  t.equal(mockComponent.state, mockComponent.props.initialState, 'it does not set state');
+
+  t.end();
+});
+
+test('eventHandlers.onPlay() when video has played before and is currently paused for version 8+', (t) => {
   let onAutoStartCalled = false;
   let onPlayCalled = false;
   let onResumeCalled = false;

--- a/test/on-play.test.js
+++ b/test/on-play.test.js
@@ -55,7 +55,7 @@ test('eventHandlers.onPlay() when video has played before and is currently pause
     },
   });
 
-  const mockEvent = { oldstate: 'buffering' };
+  const mockEvent = { oldstate: 'paused' };
   const onPlay = createEventHandlers(mockComponent).onPlay;
 
   t.doesNotThrow(onPlay.bind(null, mockEvent), 'it runs without error');

--- a/test/on-play.test.js
+++ b/test/on-play.test.js
@@ -55,7 +55,7 @@ test('eventHandlers.onPlay() when video has played before and is currently pause
     },
   });
 
-  const mockEvent = { oldstate: 'paused' };
+  const mockEvent = { oldstate: 'buffering' };
   const onPlay = createEventHandlers(mockComponent).onPlay;
 
   t.doesNotThrow(onPlay.bind(null, mockEvent), 'it runs without error');


### PR DESCRIPTION
https://github.com/micnews/react-jw-player/issues/83

Solves issue with newer versions of jw player where on resume is being triggered through 'buffering' rather than 'paused'