### PR TITLE
Init jwplayer passing DOM ref instead of id

### DIFF
--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -76,8 +76,6 @@ class ReactJWPlayer extends Component {
   _initialize() {
     const { playerId, useMultiplePlayerScripts } = this.props;
 
-    this.videoRef.id = playerId;
-
     if (useMultiplePlayerScripts) {
       setJWPlayerDefaults({ context: window, playerId });
     }
@@ -94,7 +92,7 @@ class ReactJWPlayer extends Component {
   render() {
     return (
       <div className={this.props.className} >
-        <div ref={this._setVideoRef} />
+        <div id={this.props.playerId} ref={this._setVideoRef} />
       </div>
     );
   }

--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -76,6 +76,8 @@ class ReactJWPlayer extends Component {
   _initialize() {
     const { playerId, useMultiplePlayerScripts } = this.props;
 
+    this.videoRef.id = playerId;
+
     if (useMultiplePlayerScripts) {
       setJWPlayerDefaults({ context: window, playerId });
     }

--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -29,7 +29,9 @@ class ReactJWPlayer extends Component {
       this.uniqueScriptId += `-${props.playerId}`;
     }
 
+    this.videoRef = null;
     this._initialize = this._initialize.bind(this);
+    this._setVideoRef = this._setVideoRef.bind(this);
   }
   componentDidMount() {
     const isJWPlayerScriptLoaded = !!window.jwplayer;
@@ -64,12 +66,12 @@ class ReactJWPlayer extends Component {
     return hasFileChanged || hasPlaylistChanged;
   }
   componentDidUpdate() {
-    if (window.jwplayer && window.jwplayer(this.props.playerId)) {
+    if (window.jwplayer && window.jwplayer(this.videoRef)) {
       this._initialize();
     }
   }
   componentWillUnmount() {
-    removeJWPlayerInstance(this.props.playerId, window);
+    removeJWPlayerInstance(this.videoRef, window);
   }
   _initialize() {
     const { playerId, useMultiplePlayerScripts } = this.props;
@@ -79,19 +81,18 @@ class ReactJWPlayer extends Component {
     }
 
     const component = this;
-    const player = window.jwplayer(this.props.playerId);
+    const player = window.jwplayer(this.videoRef);
     const playerOpts = getPlayerOpts(this.props);
 
     initialize({ component, player, playerOpts });
   }
+  _setVideoRef(element) {
+    this.videoRef = element;
+  }
   render() {
     return (
-      <div
-        className={this.props.className}
-        dangerouslySetInnerHTML={{ // eslint-disable-line react/no-danger
-          __html: `<div id="${this.props.playerId}"></div>`,
-        }}
-      />
+      <div ref={this._setVideoRef} className={this.props.className} >
+      </div>
     );
   }
 }

--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -92,8 +92,7 @@ class ReactJWPlayer extends Component {
   render() {
     return (
       <div className={this.props.className} >
-        <div ref={this._setVideoRef}>
-        </div>
+        <div ref={this._setVideoRef} />
       </div>
     );
   }

--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -91,7 +91,9 @@ class ReactJWPlayer extends Component {
   }
   render() {
     return (
-      <div ref={this._setVideoRef} className={this.props.className} >
+      <div className={this.props.className} >
+        <div ref={this._setVideoRef}>
+        </div>
       </div>
     );
   }

--- a/test/react-jw-player.browser-test.js
+++ b/test/react-jw-player.browser-test.js
@@ -7,6 +7,35 @@ import ReactJWPlayer from '../src/react-jw-player';
 
 jsdomGlobal();
 
+test('<ReactJWPlayer> can get video DOM element reference', (t) => {
+  const testPlayerId = 'playerOne';
+  let videoRef = null;
+
+  function stubbedInitialize() { }
+
+  function stubbedSetVideoRef(element) {
+    videoRef = element;
+  }
+
+  ReactJWPlayer.prototype._initialize = stubbedInitialize;
+  ReactJWPlayer.prototype._setVideoRef = stubbedSetVideoRef;
+
+  mount(
+    <ReactJWPlayer
+      playerId={testPlayerId}
+      playerScript='script'
+      playlist='playlist'
+    />,
+  );
+
+  t.ok(
+    !!videoRef,
+    'can get player ref',
+  );
+
+  t.end();
+});
+
 test('<ReactJWPlayer> when no jwplayer script is present', (t) => {
   const testPlayerId = 'playerOne';
   const initializeCalls = [];

--- a/test/react-jw-player.test.jsx
+++ b/test/react-jw-player.test.jsx
@@ -27,12 +27,6 @@ test('<ReactJWPlayer>', (t) => {
     'it renders a div as the root node',
   );
 
-  t.deepEqual(
-    root.props().dangerouslySetInnerHTML,
-    { __html: `<div id="${testPlayerId}"></div>` },
-    'it dangerously sets inner html to a div with the supplied id',
-  );
-
   t.end();
 });
 


### PR DESCRIPTION
Initializing jwplayer passing DOM ref allows to use this Component inside a web component