### PR TITLE
Add ability to pass player sources to support multiple video qualities (fixes #67)

### DIFF
--- a/src/helpers/get-player-opts.js
+++ b/src/helpers/get-player-opts.js
@@ -9,6 +9,7 @@ function getPlayerOpts(opts) {
     isMuted,
     licenseKey,
     playlist,
+    sources,
   } = opts;
 
   const hasAdvertising = !!generatePrerollUrl;
@@ -23,6 +24,8 @@ function getPlayerOpts(opts) {
     playerOpts.playlist = playlist;
   } else if (file) {
     playerOpts.file = file;
+  } else if (sources) {
+    playerOpts.sources = sources;
   }
 
   if (aspectRatio && aspectRatio !== 'inherit') {

--- a/src/player-prop-types.js
+++ b/src/player-prop-types.js
@@ -5,6 +5,14 @@ const propTypes = {
   className: PropTypes.string,
   customProps: PropTypes.object,
   file: PropTypes.string,
+  sources: PropTypes.arrayOf(
+    PropTypes.shape({
+      file: PropTypes.string,
+      label: PropTypes.string,
+      default: PropTypes.bool,
+      type: PropTypes.string,
+    }),
+  ),
   generatePrerollUrl: PropTypes.func,
   image: PropTypes.string,
   isAutoPlay: PropTypes.bool,


### PR DESCRIPTION
Allows the official way of adding multiple HD/SD qualities as seen here: support.jwplayer.com/articles/how-to-add-an-hd-quality-toggle

I have confirmed it works with a test build.