### PR TITLE
Windows compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js text eol=lf
+*.jsx text eol=lf

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/react-jw-player.js",
   "scripts": {
     "build": "babel src --out-dir dist",
-    "clean": "rm -rf dist",
+    "clean": "rimraf dist",
     "lint": "eslint .",
     "prepublish": "npm run lint && npm run test && npm run clean && npm run build",
     "test": "npm run lint && npm run test:unit && npm run test:browser",
@@ -56,6 +56,7 @@
     "react-addons-test-utils": "^15.4.1",
     "react-dom": "^15.4.2",
     "react-test-renderer": "^15.4.2",
+    "rimraf": "^2.6.3",
     "tape": "^4.6.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
A couple of minor compatibility improvements for developers working on Windows.

## rimraf

`rm -rf` isn’t available on Windows, so use `rimraf` from npm instead for cross-platform compatibility.

## Line endings

Add a `.gitattributes` file to force `.js` and `.jsx` files to check out with LF line endings.

By default git for Windows will check out text files with CRLF line endings, and then convert them back to LF when committing. This causes eslint to complain on Windows, because the rule `linebreak-style` is set to require LF line breaks.