### PR TITLE
Reset state when loading a new video

### DIFF
--- a/src/create-event-handlers/on-video-load.js
+++ b/src/create-event-handlers/on-video-load.js
@@ -1,6 +1,8 @@
 function onVideoLoad(event) {
   this.setState({
     hasFired: {},
+    hasPlayed: false,
+    adHasPlayed: false,
   });
   this.props.onVideoLoad(event);
 }


### PR DESCRIPTION
Reset `hasPlayed` and `adHasPlayed` when loading a new video.

This fixes an issue where `generatePrerollUrl` only gets called on the first video loaded into the player (and probably other things that rely on those pieces of state).