### PR TITLE
Add onPlayerInitialized prop

### DIFF
--- a/src/player-prop-types.js
+++ b/src/player-prop-types.js
@@ -25,6 +25,7 @@ const propTypes = {
   onOneHundredPercent: PropTypes.func,
   onPause: PropTypes.func,
   onPlay: PropTypes.func,
+  onPlayerInitialized: PropTypes.func,
   onReady: PropTypes.func,
   onResume: PropTypes.func,
   onSeventyFivePercent: PropTypes.func,

--- a/src/react-jw-player.jsx
+++ b/src/react-jw-player.jsx
@@ -74,7 +74,7 @@ class ReactJWPlayer extends Component {
     removeJWPlayerInstance(this.videoRef, window);
   }
   _initialize() {
-    const { playerId, useMultiplePlayerScripts } = this.props;
+    const { playerId, useMultiplePlayerScripts, onPlayerInitialized } = this.props;
 
     if (useMultiplePlayerScripts) {
       setJWPlayerDefaults({ context: window, playerId });
@@ -90,6 +90,10 @@ class ReactJWPlayer extends Component {
     const playerOpts = getPlayerOpts(this.props);
 
     initialize({ component, player, playerOpts });
+
+    if (onPlayerInitialized) {
+      onPlayerInitialized(player);
+    }
   }
   _setVideoRef(element) {
     this.videoRef = element;


### PR DESCRIPTION
To retrieve player instance (eg. accessing .play() or .addButton())