### PR TITLE
Fix: Updates aspectRatio prop to match jw-player doc

### DIFF
--- a/src/helpers/aspectRatioType.js
+++ b/src/helpers/aspectRatioType.js
@@ -1,0 +1,28 @@
+function aspectRatioType(props, propName, componentName = 'ANONYMOUS') {
+  if (props[propName]) {
+    const value = props[propName];
+
+    if (typeof value === 'string') {
+      const vList = value.split(':');
+
+      if (
+        value === 'inherit' ||
+        (vList.length === 2 && !isNaN(Number(vList[0])) && !isNaN(Number(vList[1])))
+      ) {
+        return null;
+      }
+
+      return new Error(
+        `Invalid prop \`${propName}\` of value \`${value}\` supplied to ${componentName}, expected a value of \`Number:Number\``,
+      );
+    }
+
+    return new Error(
+      `Invalid prop \`${propName}\` of type ${typeof value} supplied to ${componentName}, expected a value of type \`string\``,
+    );
+  }
+
+  return null;
+}
+
+export default aspectRatioType;

--- a/src/player-prop-types.js
+++ b/src/player-prop-types.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
+import aspectRatioType from './helpers/aspectRatioType';
 
 const propTypes = {
-  aspectRatio: PropTypes.oneOf(['inherit', '1:1', '16:9']),
+  aspectRatio: aspectRatioType,
   className: PropTypes.string,
   customProps: PropTypes.object,
   file: PropTypes.string,


### PR DESCRIPTION
Just a small fix to the aspectRatio prop type to better match jw-players documentation.
It now supports `N:N` (along with `inherit`) as aspectRatio.