### PR TITLE
Updated peer dependencies to include React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.10",
-    "react": "^15.4.1 || ^16.0.0"
+    "react": "^15.4.1 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "react-fast-compare": "^2.0.1"


### PR DESCRIPTION
I tested this against a React 17 build and did not run into any issues.

If there's a reason it shouldn't support React 17, feel free to reject.